### PR TITLE
Add salty food tag and enable tags filter UI

### DIFF
--- a/src/lib/components/FilterSheet.svelte
+++ b/src/lib/components/FilterSheet.svelte
@@ -205,7 +205,7 @@ export type FilterItem = {
                     />
                 </div>
 
-                <!-- <Separator />
+                <Separator />
 
                 <div class="space-y-3">
                     <h3 class="font-semibold">Tags</h3>
@@ -225,7 +225,7 @@ export type FilterItem = {
                             {/each}
                         </div>
                     </ScrollArea>
-                </div> -->
+                </div>
             </div>
         </div>
 

--- a/src/lib/types/types.ts
+++ b/src/lib/types/types.ts
@@ -61,6 +61,7 @@ export type FoodTag =
 	| "non-alcoholic"
 	| "premium-price"
 	| "pumpkin-spice"
+	| "salty"
 	| "savory"
 	| "specialty-candy"
 	| "spicy"


### PR DESCRIPTION
- Add 'salty' to FoodTag type definition in types.ts
- Uncomment tags section in FilterSheet.svelte to enable tag filtering UI
- Tags filtering logic was already implemented, now fully accessible to users

🤖 Generated with [Claude Code](https://claude.com/claude-code)