### PR TITLE
Add Troubadour Tavern holiday menu items

### DIFF
--- a/static/data/food-holiday.json
+++ b/static/data/food-holiday.json
@@ -1,3456 +1,3565 @@
 {
-	"metadata": {
-		"generatedAt": "2025-11-22T07:47:48.628Z",
-		"totalItems": 161,
-		"dataSource": "Disneyland Holiday 2025 Food Guide",
-		"filters": {
-			"locations": [
-				"California Adventure",
-				"Disneyland",
-				"Disneyland Hotel",
-				"Disney\u2019s Grand Californian Hotel & Spa",
-				"Downtown Disney District"
-			],
-			"restaurants": [
-				"Alien Pizza Planet",
-				"Bayside Brews",
-				"Beignets Expressed",
-				"Bengal Barbecue",
-				"Blue Bayou Restaurant",
-				"Boudin Bread Cart",
-				"Broken Spell Lounge",
-				"Cafe Orleans",
-				"Caf\u00e9 Daisy",
-				"California Churro",
-				"Carnation Caf\u00e9",
-				"Churros near Big Thunder Mountain Railroad and Pretzels near Big Thunder Mountain Railroad",
-				"Churros near Casey Jr. Circus Train",
-				"Churros near Redwood Creek Challenge Trail",
-				"Churros near Town Square and Sleeping Beauty Castle",
-				"Clarabelle\u2019s Hand-Scooped Ice Cream",
-				"Corn Dog Castle",
-				"Cozy Cone Motel 1 \u2013 Churros",
-				"Cozy Cone Motel 2 \u2013 Ice Cream Cones",
-				"C\u00e9ntrico",
-				"Edelweiss Snacks",
-				"Flo\u2019s V8 Cafe",
-				"GCH Craftsman Grill",
-				"Galactic Grill",
-				"Ghirardelli Soda Fountain and Chocolate Shop",
-				"Good Boy! Grocers",
-				"Goofy\u2019s Kitchen",
-				"Grand Californian Great Hall Cart",
-				"Hollywood Lounge",
-				"Jazz Kitchen Coastal Grill & Patio",
-				"Jolly Holiday Bakery Cafe",
-				"Kayla\u2019s Cake",
-				"Lamplight Lounge",
-				"Lamplight Lounge \u2013 Boardwalk Dining",
-				"Little Red Wagon",
-				"Lucky Fortune Cookery",
-				"Mint Julep Bar",
-				"Mortimers Market",
-				"Naples Ristorante e Bar",
-				"Popcorn near Haunted Mansion",
-				"Pretzels at small world Promenade",
-				"Pretzels near Star Tours \u2013 The Adventures Continue",
-				"Pym Test Kitchen",
-				"Rancho del Zocalo Restaurante",
-				"Refreshment Corner",
-				"River Belle Terrace",
-				"Royal Street Veranda",
-				"Smokejumpers Grill",
-				"Splitsville Luxury Lanes",
-				"Stage Door Caf\u00e9",
-				"Studio Catering Co.",
-				"The Coffee House",
-				"The Golden Horseshoe",
-				"Tiendita",
-				"Trader Sam\u2019s Enchanted Tiki Bar",
-				"Vista Parkside Market",
-				"Wetzel\u2019s Pretzels",
-				"Willie\u2019s Churros at Buena Vista Street",
-				"Wine Country Trattoria"
-			],
-			"categories": [
-				"baked-dessert",
-				"beer-wine",
-				"candy-snack",
-				"churro",
-				"cocktail",
-				"coffee-tea",
-				"entree",
-				"frozen-dessert",
-				"non-alcoholic-beverage",
-				"salad",
-				"savory-snack"
-			],
-			"allTags": [
-				"alcoholic",
-				"apple",
-				"character-themed",
-				"cinnamon",
-				"coffee-tea",
-				"cold",
-				"contains-nuts",
-				"cranberry",
-				"eggnog",
-				"gingerbread",
-				"hot",
-				"new",
-				"non-alcoholic",
-				"peppermint",
-				"plant-based",
-				"pumpkin-spice",
-				"savory",
-				"seasonal",
-				"vegan"
-			]
-		}
-	},
-	"items": [
-		{
-			"id": 1,
-			"name": "Holiday Dinner Special",
-			"description": "Petite New York medallions, herbed Yukon Gold mashed potatoes, haricots verts, onion straws, and cabernet demi-glace",
-			"location": "Disneyland",
-			"restaurant": "Carnation Caf\u00e9",
-			"price": null,
-			"category": "entree",
-			"itemType": "Entree",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-12-01",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Holiday-Dinner.jpg",
-			"tags": [
-				"non-alcoholic",
-				"seasonal",
-				"savory"
-			]
-		},
-		{
-			"id": 2,
-			"name": "Cosmopolitan",
-			"description": "Tito\u2019s Handmade Vodka, Cointreau, and cranberry and lime juices",
-			"location": "Disneyland",
-			"restaurant": "Carnation Caf\u00e9",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"cranberry"
-			]
-		},
-		{
-			"id": 3,
-			"name": "Eggnog Old Fashioned",
-			"description": "Buffalo Trace Bourbon, bitters, orange-infused brown sugar syrup, and candied orange peel topped with eggnog cream",
-			"location": "Disneyland",
-			"restaurant": "Carnation Caf\u00e9",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Old-Fashioned.jpg",
-			"tags": [
-				"alcoholic",
-				"eggnog"
-			]
-		},
-		{
-			"id": 4,
-			"name": "Apple Pie Dipping Sauce",
-			"description": "Cream cheese frosting topped with spiced apple compote",
-			"location": "Disneyland",
-			"restaurant": "Churros near Town Square and Sleeping Beauty Castle",
-			"price": null,
-			"category": "churro",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Apple-Dip.jpg",
-			"tags": [
-				"non-alcoholic",
-				"new",
-				"apple",
-				"cold"
-			]
-		},
-		{
-			"id": 5,
-			"name": "Gingerbread-Cranberry Cheesecake Trifle",
-			"description": "Layers of gingerbread cake, cheesecake, and cranberry compote topped with gingerbread crunch, white chocolate mousse, and a mini gingerbread man",
-			"location": "Disneyland",
-			"restaurant": "Jolly Holiday Bakery Cafe",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Cheesecake-Trifle.jpg",
-			"tags": [
-				"new",
-				"gingerbread",
-				"cranberry",
-				"non-alcoholic"
-			]
-		},
-		{
-			"id": 6,
-			"name": "Orange-Cranberry Loaf",
-			"description": "topped with cream cheese glaze and dried cranberries drizzled with white chocolate",
-			"location": "Disneyland",
-			"restaurant": "Jolly Holiday Bakery Cafe",
-			"price": null,
-			"category": "candy-snack",
-			"itemType": "Candy/Snack",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Orange-Loaf.jpg",
-			"tags": [
-				"non-alcoholic",
-				"new",
-				"cranberry"
-			]
-		},
-		{
-			"id": 7,
-			"name": "S'mores Cheesecake",
-			"description": "Chocolate cheesecake with chocolate ganache topped with marshmallow mousse and a torched marshmallow",
-			"location": "Disneyland",
-			"restaurant": "Jolly Holiday Bakery Cafe",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Smores-Cheesecake.jpg",
-			"tags": [
-				"non-alcoholic",
-				"new"
-			]
-		},
-		{
-			"id": 8,
-			"name": "Sticky Toffee Bundt Cake",
-			"description": "with toffee sauce topped with vanilla chantilly cream",
-			"location": "Disneyland",
-			"restaurant": "Jolly Holiday Bakery Cafe",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Bundt-Cake.jpg",
-			"tags": [
-				"non-alcoholic",
-				"new"
-			]
-		},
-		{
-			"id": 9,
-			"name": "White Mocha-Peppermint Tree-shaped Macaron",
-			"description": "filled with peppermint buttercream and a coffee bundt cake center",
-			"location": "Disneyland",
-			"restaurant": "Jolly Holiday Bakery Cafe",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-12-14"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Tree-Macaron.jpg",
-			"tags": [
-				"non-alcoholic",
-				"new",
-				"peppermint",
-				"coffee-tea"
-			]
-		},
-		{
-			"id": 10,
-			"name": "Mickey Gingerbread",
-			"description": "Soft gingerbread Mickey cookie (Limit five per person, per transaction)",
-			"location": "Disneyland",
-			"restaurant": "Jolly Holiday Bakery Cafe",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Mickey-Gingerbread.jpg",
-			"tags": [
-				"gingerbread",
-				"character-themed",
-				"non-alcoholic"
-			]
-		},
-		{
-			"id": 11,
-			"name": "Mickey-shaped Holiday Cookie",
-			"description": "Shortbread cookie dipped in white chocolate with holiday sprinkles, and a chocolate Mickey decoration",
-			"location": "Disneyland",
-			"restaurant": "Jolly Holiday Bakery Cafe",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Mickey-Cookie.jpg",
-			"tags": [
-				"non-alcoholic",
-				"character-themed",
-				"seasonal"
-			]
-		},
-		{
-			"id": 12,
-			"name": "Pumpkin Muffin",
-			"description": "topped with cream cheese icing",
-			"location": "Disneyland",
-			"restaurant": "Jolly Holiday Bakery Cafe",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"pumpkin-spice"
-			]
-		},
-		{
-			"id": 13,
-			"name": "Peppermint Cold Brew",
-			"description": "topped with vanilla foam and holiday sugar",
-			"location": "Disneyland",
-			"restaurant": "Jolly Holiday Bakery Cafe",
-			"price": null,
-			"category": "coffee-tea",
-			"itemType": "Coffee/Tea",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Peppermint-Cold-Brew.jpg",
-			"tags": [
-				"non-alcoholic",
-				"peppermint",
-				"seasonal",
-				"cold"
-			]
-		},
-		{
-			"id": 14,
-			"name": "Chili Cheese Corn Dog",
-			"description": "Classic corn dog topped with spicy chili, jalape\u00f1o-cilantro crema, cheddar cheese, and crispy onions served with choice of Cuties Mandarin Orange or potato chips",
-			"location": "Disneyland",
-			"restaurant": "Little Red Wagon",
-			"price": null,
-			"category": "savory-snack",
-			"itemType": "Savory Snack",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Corn-Dog.jpg",
-			"tags": [
-				"non-alcoholic",
-				"character-themed"
-			]
-		},
-		{
-			"id": 15,
-			"name": "Blood Orange & Hibiscus Limeade",
-			"description": "garnished with dried fruit",
-			"location": "Disneyland",
-			"restaurant": "Little Red Wagon",
-			"price": null,
-			"category": "non-alcoholic-beverage",
-			"itemType": "Non-Alcoholic Beverage",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Orange-Lemonade.jpg",
-			"tags": [
-				"non-alcoholic"
-			]
-		},
-		{
-			"id": 16,
-			"name": "Warm Spiced Apple Tea",
-			"description": "with hints of cinnamon and clove topped with vanilla cream foam",
-			"location": "Disneyland",
-			"restaurant": "Refreshment Corner",
-			"price": null,
-			"category": "coffee-tea",
-			"itemType": "Coffee/Tea",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Philly-Potato.jpg",
-			"tags": [
-				"non-alcoholic",
-				"apple",
-				"cinnamon",
-				"coffee-tea",
-				"cold",
-				"hot"
-			]
-		},
-		{
-			"id": 17,
-			"name": "Vietnamese Iced Coffee",
-			"description": "with brown sugar spheres and cold foam",
-			"location": "Disneyland",
-			"restaurant": "Bengal Barbecue",
-			"price": null,
-			"category": "coffee-tea",
-			"itemType": "Coffee/Tea",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Vietnamese-Coffee.jpg",
-			"tags": [
-				"non-alcoholic",
-				"new",
-				"coffee-tea",
-				"cold"
-			]
-		},
-		{
-			"id": 18,
-			"name": "Iced Pandan Cooler",
-			"description": "with brown sugar spheres and ube cold foam",
-			"location": "Disneyland",
-			"restaurant": "Bengal Barbecue",
-			"price": null,
-			"category": "non-alcoholic-beverage",
-			"itemType": "Non-Alcoholic Beverage",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Pandan-Cooler.jpg",
-			"tags": [
-				"non-alcoholic",
-				"cold"
-			]
-		},
-		{
-			"id": 19,
-			"name": "Chocolate Peppermint Dipping Sauce",
-			"description": "",
-			"location": "Disneyland",
-			"restaurant": "Churros near Big Thunder Mountain Railroad and Pretzels near Big Thunder Mountain Railroad",
-			"price": null,
-			"category": "churro",
-			"itemType": "Candy/Snack",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Peppermint-Dip.jpg",
-			"tags": [
-				"non-alcoholic",
-				"new",
-				"peppermint"
-			]
-		},
-		{
-			"id": 20,
-			"name": "Chocolate Cake Flan",
-			"description": "Chocolate cake and flan topped with caramel sauce, whipped cream, and cinnamon dust",
-			"location": "Disneyland",
-			"restaurant": "Rancho del Zocalo Restaurante",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Chocolate-Flan.jpg",
-			"tags": [
-				"non-alcoholic",
-				"cinnamon"
-			]
-		},
-		{
-			"id": 21,
-			"name": "Hibiscus-Pomegranate Cooler",
-			"description": "Spiced hibiscus tea, pomegranate and orange juices, and honey",
-			"location": "Disneyland",
-			"restaurant": "Rancho del Zocalo Restaurante",
-			"price": null,
-			"category": "non-alcoholic-beverage",
-			"itemType": "Coffee/Tea",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Pomegranate-Cooler.jpg",
-			"tags": [
-				"non-alcoholic",
-				"coffee-tea",
-				"cold"
-			]
-		},
-		{
-			"id": 22,
-			"name": "Sticky Toffee Pudding",
-			"description": "Vanilla pudding, sticky toffee cake, and candy pecans",
-			"location": "Disneyland",
-			"restaurant": "River Belle Terrace",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Chess-Pie.jpg",
-			"tags": [
-				"non-alcoholic",
-				"contains-nuts"
-			]
-		},
-		{
-			"id": 23,
-			"name": "Wreath Funnel Cake",
-			"description": "Green funnel cake with caramel sauce, apple filling, whipped topping, and holiday sprinkles",
-			"location": "Disneyland",
-			"restaurant": "Stage Door Caf\u00e9",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Funnel-Cake.jpg",
-			"tags": [
-				"non-alcoholic",
-				"apple",
-				"seasonal"
-			]
-		},
-		{
-			"id": 24,
-			"name": "Gingerbread Sundae",
-			"description": "Gingerbread cake with vanilla ice cream and whipped topping",
-			"location": "Disneyland",
-			"restaurant": "The Golden Horseshoe",
-			"price": null,
-			"category": "frozen-dessert",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"gingerbread",
-				"non-alcoholic"
-			]
-		},
-		{
-			"id": 25,
-			"name": "Sticky Toffee Cake",
-			"description": "soaked in bourbon toffee sauce and garnished with candied walnuts and vanilla ice cream",
-			"location": "Disneyland",
-			"restaurant": "Blue Bayou Restaurant",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Toffee-Cake.jpg",
-			"tags": [
-				"new",
-				"contains-nuts",
-				"non-alcoholic"
-			]
-		},
-		{
-			"id": 26,
-			"name": "Roasted Beet and Citrus Salad",
-			"description": "Crema, herbs, almonds, fennel, and poppy seed vinaigrette",
-			"location": "Disneyland",
-			"restaurant": "Blue Bayou Restaurant",
-			"price": null,
-			"category": "salad",
-			"itemType": "Salad",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"plant-based",
-				"vegan",
-				"contains-nuts"
-			]
-		},
-		{
-			"id": 27,
-			"name": "Holiday Sangria",
-			"description": "Cocktail-inspired seltzer with cinnamon",
-			"location": "Disneyland",
-			"restaurant": "Blue Bayou Restaurant",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"new",
-				"cinnamon",
-				"seasonal"
-			]
-		},
-		{
-			"id": 28,
-			"name": "Cherry Cream Soda",
-			"description": "Sprite, cherry syrup, and cream",
-			"location": "Disneyland",
-			"restaurant": "Cafe Orleans",
-			"price": null,
-			"category": "non-alcoholic-beverage",
-			"itemType": "Non-Alcoholic Beverage",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic"
-			]
-		},
-		{
-			"id": 29,
-			"name": "Holiday Sangria",
-			"description": "Cocktail-inspired seltzer with cinnamon",
-			"location": "Disneyland",
-			"restaurant": "Cafe Orleans",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"new",
-				"cinnamon",
-				"seasonal"
-			]
-		},
-		{
-			"id": 30,
-			"name": "Peppermint Mickey-shaped Beignets",
-			"description": "dusted in peppermint powdered sugar",
-			"location": "Disneyland",
-			"restaurant": "Mint Julep Bar",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Beignets.jpg",
-			"tags": [
-				"non-alcoholic",
-				"peppermint",
-				"character-themed"
-			]
-		},
-		{
-			"id": 31,
-			"name": "Whipped Chocolate-Peppermint Dip",
-			"description": "",
-			"location": "Disneyland",
-			"restaurant": "Mint Julep Bar",
-			"price": null,
-			"category": "candy-snack",
-			"itemType": "Candy/Snack",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Peppermint-Dip-1.jpg",
-			"tags": [
-				"non-alcoholic",
-				"peppermint"
-			]
-		},
-		{
-			"id": 32,
-			"name": "Cranberry-Pomegranate Mint Julep",
-			"description": "with mixed berry-flavored popping spheres",
-			"location": "Disneyland",
-			"restaurant": "Mint Julep Bar",
-			"price": null,
-			"category": "non-alcoholic-beverage",
-			"itemType": "Non-Alcoholic Beverage",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Cranberry-Julep.jpg",
-			"tags": [
-				"non-alcoholic",
-				"cranberry"
-			]
-		},
-		{
-			"id": 33,
-			"name": "Holiday Treats Mix-in",
-			"description": "Add on a scoop of holiday candy mix to classic buttery popcorn, complete with red and green M&M'S Milk Chocolate Candies and mini marshmallows",
-			"location": "Disneyland",
-			"restaurant": "Popcorn near Haunted Mansion",
-			"price": null,
-			"category": "savory-snack",
-			"itemType": "Savory Snack",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Holiday-Popcorn.jpg",
-			"tags": [
-				"non-alcoholic",
-				"seasonal"
-			]
-		},
-		{
-			"id": 34,
-			"name": "Roasted Vegetable Salad",
-			"description": "Roasted Brussels sprouts, beets, butternut squash, yams, and burrata cheese with herbed balsamic vinaigrette",
-			"location": "Disneyland",
-			"restaurant": "Royal Street Veranda",
-			"price": null,
-			"category": "salad",
-			"itemType": "Salad",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Vegetable-Salad.jpg",
-			"tags": [
-				"non-alcoholic"
-			]
-		},
-		{
-			"id": 35,
-			"name": "Coffee Fritters",
-			"description": "rolled in cinnamon sugar, drizzled with white mocha sauce, and garnished with praline sugar streusel",
-			"location": "Disneyland",
-			"restaurant": "Royal Street Veranda",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Coffee/Tea",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Coffee-Fritters.jpg",
-			"tags": [
-				"non-alcoholic",
-				"cinnamon",
-				"coffee-tea"
-			]
-		},
-		{
-			"id": 36,
-			"name": "Hot Spiced Apple Cider",
-			"description": "topped with caramel whipped cream",
-			"location": "Disneyland",
-			"restaurant": "Royal Street Veranda",
-			"price": null,
-			"category": "beer-wine",
-			"itemType": "Beer/Wine",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Apple-Cider.jpg",
-			"tags": [
-				"non-alcoholic",
-				"new",
-				"apple",
-				"cold",
-				"hot"
-			]
-		},
-		{
-			"id": 37,
-			"name": "Gingerbread Churro",
-			"description": "Classic churro rolled in gingerbread sugar dust",
-			"location": "Disneyland",
-			"restaurant": "Churros near Casey Jr. Circus Train",
-			"price": null,
-			"category": "churro",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Stew.jpg",
-			"tags": [
-				"gingerbread",
-				"non-alcoholic"
-			]
-		},
-		{
-			"id": 38,
-			"name": "Butterscotch Dipping Sauce",
-			"description": "Butterscotch caramel dip",
-			"location": "Disneyland",
-			"restaurant": "Churros near Casey Jr. Circus Train",
-			"price": null,
-			"category": "churro",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic"
-			]
-		},
-		{
-			"id": 39,
-			"name": "Black Forest Cake",
-			"description": "Chocolate sponge cake filled with cherries and topped with chocolate ganache, chantilly cr\u00e8me, chocolate curls, cherries, and powdered sugar",
-			"location": "Disneyland",
-			"restaurant": "Edelweiss Snacks",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic"
-			]
-		},
-		{
-			"id": 40,
-			"name": "Butterscotch Dipping Sauce",
-			"description": "Butterscotch caramel dip",
-			"location": "Disneyland",
-			"restaurant": "Pretzels at small world Promenade",
-			"price": null,
-			"category": "churro",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic"
-			]
-		},
-		{
-			"id": 41,
-			"name": "Daisy\u2019s Goody-Goody Donuts",
-			"description": "House-made mini apple cider donuts with spiced apple sugar",
-			"location": "Disneyland",
-			"restaurant": "Caf\u00e9 Daisy",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Apple-Donuts.jpg",
-			"tags": [
-				"apple",
-				"character-themed",
-				"cold",
-				"non-alcoholic"
-			]
-		},
-		{
-			"id": 42,
-			"name": "Very Merry Cran-Peary",
-			"description": "Minute Maid Zero Sugar Lemonade with cranberry and pear syrups garnished with cranberries and a fresh rosemary sprig",
-			"location": "Disneyland",
-			"restaurant": "Caf\u00e9 Daisy",
-			"price": null,
-			"category": "non-alcoholic-beverage",
-			"itemType": "Non-Alcoholic Beverage",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Daisy-Cranberry.jpg",
-			"tags": [
-				"non-alcoholic",
-				"cranberry"
-			]
-		},
-		{
-			"id": 43,
-			"name": "Strawberry Slushie with Fanta S",
-			"description": "trawberry (Also available with Orb Sipper)",
-			"location": "Disneyland",
-			"restaurant": "Good Boy! Grocers",
-			"price": null,
-			"category": "non-alcoholic-beverage",
-			"itemType": "Non-Alcoholic Beverage",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"new"
-			]
-		},
-		{
-			"id": 44,
-			"name": "Claw-sagna Pasta",
-			"description": "Campanelle pasta tossed in ricotta and mozzarella sauce, topped with bolognese sauce and garnished with toasted breadcrumbs, parmesan, and basil",
-			"location": "Disneyland",
-			"restaurant": "Alien Pizza Planet",
-			"price": null,
-			"category": "entree",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Pasta.jpg",
-			"tags": [
-				"non-alcoholic"
-			]
-		},
-		{
-			"id": 45,
-			"name": "Apple and Pecan Salad",
-			"description": "Mixed greens with fris\u00e9e, candied pecans, Granny Smith apple, feta crumbles, and maple dressing",
-			"location": "Disneyland",
-			"restaurant": "Alien Pizza Planet",
-			"price": null,
-			"category": "salad",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"apple",
-				"contains-nuts",
-				"non-alcoholic"
-			]
-		},
-		{
-			"id": 46,
-			"name": "Alien Reindeer Macarooooon",
-			"description": "filled with salted caramel buttercream, chocolate ganache, and brownie pieces",
-			"location": "Disneyland",
-			"restaurant": "Alien Pizza Planet",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Reindeer-Macaron.jpg",
-			"tags": [
-				"non-alcoholic"
-			]
-		},
-		{
-			"id": 47,
-			"name": "Holiday Green Drink",
-			"description": "Apple-flavored beverage topped with caramel cold foam and sprinkles",
-			"location": "Disneyland",
-			"restaurant": "Alien Pizza Planet",
-			"price": null,
-			"category": "candy-snack",
-			"itemType": "Candy/Snack",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Green-Drink.jpg",
-			"tags": [
-				"non-alcoholic",
-				"apple",
-				"seasonal",
-				"cold"
-			]
-		},
-		{
-			"id": 48,
-			"name": "Holiday Parfait",
-			"description": "Layers of chocolate cake, edible cookie dough, marshmallow mousse, chocolate crunch, chocolate mousse, and ganache finished with colored mousse, star glitter, and truffle shell",
-			"location": "Disneyland",
-			"restaurant": "Galactic Grill",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Holiday-Parfait.jpg",
-			"tags": [
-				"non-alcoholic",
-				"new",
-				"seasonal"
-			]
-		},
-		{
-			"id": 49,
-			"name": "Holiday Punch",
-			"description": "Pomegranate, cranberry, and orange juices and Sprite, garnished with cranberries, orange wedge, and a rosemary sprig",
-			"location": "Disneyland",
-			"restaurant": "Galactic Grill",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Christmas-Punch.jpg",
-			"tags": [
-				"non-alcoholic",
-				"cranberry",
-				"seasonal"
-			]
-		},
-		{
-			"id": 50,
-			"name": "Holiday Chocolate Foam Cold Brew",
-			"description": "Joffrey's Cold Brew Coffee with a splash of hazelnut syrup, topped with hot chocolate foam and garnished with cinnamon-flavored cereal",
-			"location": "Disneyland",
-			"restaurant": "Galactic Grill",
-			"price": null,
-			"category": "coffee-tea",
-			"itemType": "Coffee/Tea",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Chocolate-Cold-Brew.jpg",
-			"tags": [
-				"non-alcoholic",
-				"cinnamon",
-				"seasonal",
-				"coffee-tea",
-				"cold",
-				"hot",
-				"contains-nuts"
-			]
-		},
-		{
-			"id": 51,
-			"name": "Toffee Pretzel",
-			"description": "Cream cheese-filled pretzel with toffee sugar",
-			"location": "Disneyland",
-			"restaurant": "Pretzels near Star Tours \u2013 The Adventures Continue",
-			"price": null,
-			"category": "candy-snack",
-			"itemType": "Savory Snack",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Toffee-Pretzel.jpg",
-			"tags": [
-				"non-alcoholic"
-			]
-		},
-		{
-			"id": 52,
-			"name": "Chocolate-Peppermint Sundae",
-			"description": "Chocolate and peppermint ice cream in a waffle cup, topped with whipped cream and peppermint candy",
-			"location": "California Adventure",
-			"restaurant": "Clarabelle\u2019s Hand-Scooped Ice Cream",
-			"price": null,
-			"category": "frozen-dessert",
-			"itemType": "Frozen Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Peppermint-Sundae.jpg",
-			"tags": [
-				"non-alcoholic",
-				"peppermint"
-			]
-		},
-		{
-			"id": 53,
-			"name": "Peppermint Ice Cream",
-			"description": "",
-			"location": "California Adventure",
-			"restaurant": "Clarabelle\u2019s Hand-Scooped Ice Cream",
-			"price": null,
-			"category": "frozen-dessert",
-			"itemType": "Frozen Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"peppermint"
-			]
-		},
-		{
-			"id": 54,
-			"name": "Christmas Tree Pull-apart Sourdough Bread",
-			"description": "",
-			"location": "California Adventure",
-			"restaurant": "Mortimers Market",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Sourdough-Tree.jpg",
-			"tags": [
-				"non-alcoholic",
-				"plant-based",
-				"vegan"
-			]
-		},
-		{
-			"id": 55,
-			"name": "Carrot Cake Churro",
-			"description": "Classic churro topped with carrot cake pieces and cream cheese",
-			"location": "California Adventure",
-			"restaurant": "Willie's Churros at Buena Vista Street",
-			"price": null,
-			"category": "churro",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Carrot-Churro.jpg",
-			"tags": [
-				"non-alcoholic"
-			]
-		},
-		{
-			"id": 56,
-			"name": "Apple-Tamarind Agua Fresca",
-			"description": "garnished with a dried apple slide",
-			"location": "California Adventure",
-			"restaurant": "Hollywood Lounge",
-			"price": null,
-			"category": "non-alcoholic-beverage",
-			"itemType": "Non-Alcoholic Beverage",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Agua-Fresca.jpg",
-			"tags": [
-				"non-alcoholic",
-				"new",
-				"apple"
-			]
-		},
-		{
-			"id": 57,
-			"name": "Brooklyn Brewery Brown Ale",
-			"description": "",
-			"location": "California Adventure",
-			"restaurant": "Hollywood Lounge",
-			"price": null,
-			"category": "beer-wine",
-			"itemType": "Beer/Wine",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"new"
-			]
-		},
-		{
-			"id": 58,
-			"name": "Spiced Pomegranate Cocktail",
-			"description": "",
-			"location": "California Adventure",
-			"restaurant": "Hollywood Lounge",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Pomegranate-Cocktail.jpg",
-			"tags": [
-				"non-alcoholic",
-				"new",
-				"cold"
-			]
-		},
-		{
-			"id": 59,
-			"name": "Study Break Beverage Company Cranberry Mule",
-			"description": "",
-			"location": "California Adventure",
-			"restaurant": "Hollywood Lounge",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Cranberry-Mule.jpg",
-			"tags": [
-				"alcoholic",
-				"new",
-				"cranberry"
-			]
-		},
-		{
-			"id": 60,
-			"name": "Unsung Brewing Company Blood Orange Seltzer",
-			"description": "",
-			"location": "California Adventure",
-			"restaurant": "Hollywood Lounge",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Orange-Seltzer.jpg",
-			"tags": [
-				"alcoholic",
-				"new"
-			]
-		},
-		{
-			"id": 61,
-			"name": "Seaborn Cocktails CranMerry Lime Margarita",
-			"description": "",
-			"location": "California Adventure",
-			"restaurant": "Hollywood Lounge",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic"
-			]
-		},
-		{
-			"id": 62,
-			"name": "Apple-Tamarind Agua Fresca",
-			"description": "garnished with a dried apple slide",
-			"location": "California Adventure",
-			"restaurant": "Studio Catering Co.",
-			"price": null,
-			"category": "non-alcoholic-beverage",
-			"itemType": "Non-Alcoholic Beverage",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Agua-Fresca.jpg",
-			"tags": [
-				"non-alcoholic",
-				"new",
-				"apple"
-			]
-		},
-		{
-			"id": 63,
-			"name": "Asgardian Apple Cold Brew",
-			"description": "Caramel cold brew, green apple cold foam, and caramel sauce with a caramel apple lollipop",
-			"location": "California Adventure",
-			"restaurant": "Pym Test Kitchen",
-			"price": null,
-			"category": "coffee-tea",
-			"itemType": "Coffee/Tea",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Chimichanga.jpg",
-			"tags": [
-				"non-alcoholic",
-				"apple",
-				"cold"
-			]
-		},
-		{
-			"id": 64,
-			"name": "Blueberry Matcha Iced Latte",
-			"description": "Matcha latte topped with blueberry cold foam and blueberry popping spheres",
-			"location": "California Adventure",
-			"restaurant": "Pym Test Kitchen",
-			"price": null,
-			"category": "coffee-tea",
-			"itemType": "Coffee/Tea",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"coffee-tea",
-				"cold"
-			]
-		},
-		{
-			"id": 65,
-			"name": "Newtopia Cyder Soiree Five Apple Blend",
-			"description": "",
-			"location": "California Adventure",
-			"restaurant": "Pym Test Kitchen",
-			"price": null,
-			"category": "beer-wine",
-			"itemType": "Beer/Wine",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"new",
-				"apple"
-			]
-		},
-		{
-			"id": 66,
-			"name": "Chocolate Cr\u00e8me Br\u00fbl\u00e9e Tart",
-			"description": "Raspberries and coconut chantilly cream",
-			"location": "California Adventure",
-			"restaurant": "Wine Country Trattoria",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"plant-based",
-				"vegan"
-			]
-		},
-		{
-			"id": 67,
-			"name": "Mulled Wine",
-			"description": "Holiday-spiced warm wine",
-			"location": "California Adventure",
-			"restaurant": "Wine Country Trattoria",
-			"price": null,
-			"category": "beer-wine",
-			"itemType": "Beer/Wine",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"new",
-				"seasonal",
-				"cold",
-				"hot"
-			]
-		},
-		{
-			"id": 68,
-			"name": "Pumpkin Cr\u00e8me Br\u00fbl\u00e9e Cold Brew: Joffrey\u2019s",
-			"description": "Pumpkin cr\u00e8me br\u00fbl\u00e9e cold brew coffee with pumpkin sauce topped with cold cream foam",
-			"location": "California Adventure",
-			"restaurant": "Cozy Cone Motel 1 \u2013 Churros",
-			"price": null,
-			"category": "coffee-tea",
-			"itemType": "Coffee/Tea",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Apple-Churro.jpg",
-			"tags": [
-				"non-alcoholic",
-				"pumpkin-spice",
-				"coffee-tea",
-				"cold"
-			]
-		},
-		{
-			"id": 69,
-			"name": "Hot Chocolate Vodka Cocktail",
-			"description": "with vanilla vodka topped with whipped cream and peppermint candy",
-			"location": "California Adventure",
-			"restaurant": "Cozy Cone Motel 1 \u2013 Churros",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Cocoa-Cocktail.jpg",
-			"tags": [
-				"alcoholic",
-				"new",
-				"peppermint",
-				"hot"
-			]
-		},
-		{
-			"id": 70,
-			"name": "Cars-mas Tree Cone",
-			"description": "Peppermint soft serve decorated with holiday sprinkles",
-			"location": "California Adventure",
-			"restaurant": "Cozy Cone Motel 2 \u2013 Ice Cream Cones",
-			"price": null,
-			"category": "frozen-dessert",
-			"itemType": "Frozen Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"peppermint",
-				"seasonal"
-			]
-		},
-		{
-			"id": 71,
-			"name": "Peppermint-Chocolate Twist Soft Serve",
-			"description": "",
-			"location": "California Adventure",
-			"restaurant": "Cozy Cone Motel 2 \u2013 Ice Cream Cones",
-			"price": null,
-			"category": "frozen-dessert",
-			"itemType": "Frozen Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"peppermint"
-			]
-		},
-		{
-			"id": 72,
-			"name": "Peppermint Soft Serve",
-			"description": "",
-			"location": "California Adventure",
-			"restaurant": "Cozy Cone Motel 2 \u2013 Ice Cream Cones",
-			"price": null,
-			"category": "frozen-dessert",
-			"itemType": "Frozen Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"peppermint"
-			]
-		},
-		{
-			"id": 73,
-			"name": "Apple Crumble",
-			"description": "topped with vanilla chantilly cream",
-			"location": "California Adventure",
-			"restaurant": "Flo\u2019s V8 Cafe",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Apple-Crumble.jpg",
-			"tags": [
-				"new",
-				"apple",
-				"non-alcoholic"
-			]
-		},
-		{
-			"id": 74,
-			"name": "Candy Cane Sourdough Bread (Plant-based)",
-			"description": "",
-			"location": "California Adventure",
-			"restaurant": "Boudin Bread Cart",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"plant-based",
-				"vegan"
-			]
-		},
-		{
-			"id": 75,
-			"name": "Christmas Tree Pull-apart Sourdough Bread (Plant-based)",
-			"description": "",
-			"location": "California Adventure",
-			"restaurant": "Boudin Bread Cart",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"plant-based",
-				"vegan"
-			]
-		},
-		{
-			"id": 76,
-			"name": "Snowman Sourdough Bread (Plant-based)",
-			"description": "",
-			"location": "California Adventure",
-			"restaurant": "Boudin Bread Cart",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"plant-based",
-				"vegan"
-			]
-		},
-		{
-			"id": 77,
-			"name": "Ghirardelli Mexican Style Hot Cocoa",
-			"description": "Warm cinnamon and nutmeg along with a subtle bit of spice from cayenne mixed with Ghirardelli hot cocoa, topped with hot fudge whipped cream",
-			"location": "California Adventure",
-			"restaurant": "Ghirardelli Soda Fountain and Chocolate Shop",
-			"price": null,
-			"category": "candy-snack",
-			"itemType": "Candy/Snack",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Ghirardelli-1440x1080.jpg",
-			"tags": [
-				"non-alcoholic",
-				"new",
-				"cinnamon",
-				"hot"
-			]
-		},
-		{
-			"id": 78,
-			"name": "Santa Baymax Macaron",
-			"description": "filled with peppermint buttercream, chocolate ganache, and dark chocolate crunchies",
-			"location": "California Adventure",
-			"restaurant": "Lucky Fortune Cookery",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Baymax-Macaron.jpg",
-			"tags": [
-				"non-alcoholic",
-				"peppermint"
-			]
-		},
-		{
-			"id": 79,
-			"name": "Brewery Ommegang Everything Naughty",
-			"description": "White chocolate imperial blonde stout",
-			"location": "California Adventure",
-			"restaurant": "Lamplight Lounge \u2013 Boardwalk Dining",
-			"price": null,
-			"category": "beer-wine",
-			"itemType": "Beer/Wine",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Caramel-Donuts.jpg",
-			"tags": [
-				"alcoholic",
-				"new"
-			]
-		},
-		{
-			"id": 80,
-			"name": "Java Martini",
-			"description": "Tequila, coffee and vanilla liqueurs, and hazelnut cream cold foam",
-			"location": "California Adventure",
-			"restaurant": "Lamplight Lounge \u2013 Boardwalk Dining",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"new",
-				"coffee-tea",
-				"cold",
-				"contains-nuts"
-			]
-		},
-		{
-			"id": 81,
-			"name": "Lamplight Delight Donuts",
-			"description": "",
-			"location": "California Adventure",
-			"restaurant": "Lamplight Lounge",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Caramel-Donuts.jpg",
-			"tags": [
-				"non-alcoholic",
-				"new"
-			]
-		},
-		{
-			"id": 82,
-			"name": "Java Martini",
-			"description": "Tequila, coffee and vanilla liqueurs, and hazelnut cream cold foam",
-			"location": "California Adventure",
-			"restaurant": "Lamplight Lounge",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"new",
-				"coffee-tea",
-				"cold",
-				"contains-nuts"
-			]
-		},
-		{
-			"id": 83,
-			"name": "2 Towns Ciderhouse Cosmic Crisp",
-			"description": "",
-			"location": "California Adventure",
-			"restaurant": "Lamplight Lounge",
-			"price": null,
-			"category": "beer-wine",
-			"itemType": "Beer/Wine",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic"
-			]
-		},
-		{
-			"id": 84,
-			"name": "Brewery X Spiced Sangria Seltzer",
-			"description": "Fruity and light spiced sangria seltzer (Michelada option available)",
-			"location": "California Adventure",
-			"restaurant": "Bayside Brews",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Michelada.jpg",
-			"tags": [
-				"alcoholic",
-				"cold"
-			]
-		},
-		{
-			"id": 85,
-			"name": "Rincon Reservation Road Rez Dog Hefeweizen",
-			"description": "(Michelada option available)",
-			"location": "California Adventure",
-			"restaurant": "Bayside Brews",
-			"price": null,
-			"category": "beer-wine",
-			"itemType": "Beer/Wine",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic"
-			]
-		},
-		{
-			"id": 86,
-			"name": "Watermelon Pineapple Margarita",
-			"description": "Tequila, watermelon schnapps, and pineapple juice with a chile-lime-seasoned rim",
-			"location": "California Adventure",
-			"restaurant": "Bayside Brews",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Watermelon-Margarita.jpg",
-			"tags": [
-				"alcoholic",
-				"apple"
-			]
-		},
-		{
-			"id": 87,
-			"name": "Fried Elote Corn on the Cob",
-			"description": "dipped in batter and fried to golden brown, drizzled with chipotle a\u00efoli, and topped with chile-lime queso fresco and cilantro served with Cuties Mandarin Orange or small bag of chips",
-			"location": "California Adventure",
-			"restaurant": "Corn Dog Castle",
-			"price": null,
-			"category": "savory-snack",
-			"itemType": "Savory Snack",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Fried-Elote.jpg",
-			"tags": [
-				"non-alcoholic",
-				"character-themed"
-			]
-		},
-		{
-			"id": 88,
-			"name": "Fluffernutter Churro",
-			"description": "Classic churro with peanut butter sauce, marshmallow sauce, and chocolate chips",
-			"location": "California Adventure",
-			"restaurant": "Churros near Redwood Creek Challenge Trail",
-			"price": null,
-			"category": "churro",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Fluffernutter-Churro.jpg",
-			"tags": [
-				"non-alcoholic",
-				"character-themed"
-			]
-		},
-		{
-			"id": 89,
-			"name": "BearPaw Basin Cold Brew",
-			"description": "Joffrey\u2019s Pecan cold brew coffee, salted maple cold foam, caramel drizzle, and waffle pieces (Non-alocholic)",
-			"location": "California Adventure",
-			"restaurant": "Smokejumpers Grill",
-			"price": null,
-			"category": "coffee-tea",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Basin-Cold-Brew.jpg",
-			"tags": [
-				"non-alcoholic",
-				"coffee-tea",
-				"cold",
-				"contains-nuts"
-			]
-		},
-		{
-			"id": 90,
-			"name": "Peppermint Mocha Shake",
-			"description": "Joffrey's Peppermint, chocolate, and coffee shake with whipped topping and peppermint candy pieces",
-			"location": "California Adventure",
-			"restaurant": "Smokejumpers Grill",
-			"price": null,
-			"category": "frozen-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Peppermint-Shake.jpg",
-			"tags": [
-				"non-alcoholic",
-				"peppermint",
-				"coffee-tea"
-			]
-		},
-		{
-			"id": 91,
-			"name": "Karl Strauss Aurora Hoppyalis IPA",
-			"description": "",
-			"location": "California Adventure",
-			"restaurant": "Smokejumpers Grill",
-			"price": null,
-			"category": "beer-wine",
-			"itemType": "Beer/Wine",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"new"
-			]
-		},
-		{
-			"id": 92,
-			"name": "Kona Brewing Co. Longboard Island Lager",
-			"description": "",
-			"location": "California Adventure",
-			"restaurant": "Smokejumpers Grill",
-			"price": null,
-			"category": "beer-wine",
-			"itemType": "Beer/Wine",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"new"
-			]
-		},
-		{
-			"id": 93,
-			"name": "Caramel-Pecan Irish Cream Cold Brew Cocktail",
-			"description": "Irish cream liqueur, Joffrey's pecan cold brew coffee, salted maple cold foam, caramel drizzle, and waffle pieces",
-			"location": "California Adventure",
-			"restaurant": "Smokejumpers Grill",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Pecan-Cocktail.jpg",
-			"tags": [
-				"alcoholic",
-				"coffee-tea",
-				"cold",
-				"contains-nuts"
-			]
-		},
-		{
-			"id": 94,
-			"name": "Eggnog",
-			"description": "House-made eggnog",
-			"location": "Disneyland Hotel",
-			"restaurant": "Broken Spell Lounge",
-			"price": null,
-			"category": "non-alcoholic-beverage",
-			"itemType": "Non-Alcoholic Beverage",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Marshmallow-Cocktail.jpg",
-			"tags": [
-				"non-alcoholic",
-				"eggnog"
-			]
-		},
-		{
-			"id": 95,
-			"name": "Hot Chocolate",
-			"description": "House-made hot chocolate",
-			"location": "Disneyland Hotel",
-			"restaurant": "Broken Spell Lounge",
-			"price": null,
-			"category": "candy-snack",
-			"itemType": "Candy/Snack",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"hot"
-			]
-		},
-		{
-			"id": 96,
-			"name": "Coal Manhattan",
-			"description": "WhistlePig PiggyBack 6-Year Rye, Amaro Averna, St. Elizabeth Allspice Dram, and bitters",
-			"location": "Disneyland Hotel",
-			"restaurant": "Broken Spell Lounge",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic"
-			]
-		},
-		{
-			"id": 97,
-			"name": "Eggnog Cocktail",
-			"description": "House-made eggnog, Fonseca Bin 27 Port, Pierre Ferrand Cognac, and Smith & Cross Jamaican Pot Still Rum",
-			"location": "Disneyland Hotel",
-			"restaurant": "Broken Spell Lounge",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"eggnog"
-			]
-		},
-		{
-			"id": 98,
-			"name": "Five Golden Rings",
-			"description": "Golden Eagle Vodka, St-Germain Elderflower Liqueur, ginger, rosemary, cranberry flavors with edible shimmer glitter",
-			"location": "Disneyland Hotel",
-			"restaurant": "Broken Spell Lounge",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"cranberry"
-			]
-		},
-		{
-			"id": 99,
-			"name": "Hot Chocolate Cocktail",
-			"description": "House-made hot chocolate with Plantation Dark Rum and Drambuie Liquor",
-			"location": "Disneyland Hotel",
-			"restaurant": "Broken Spell Lounge",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"hot"
-			]
-		},
-		{
-			"id": 100,
-			"name": "Mulled Wine",
-			"description": "The Fableist Wine Company The Silkworm and the Spider Pinot Noir with mulled spices served over ice",
-			"location": "Disneyland Hotel",
-			"restaurant": "Broken Spell Lounge",
-			"price": null,
-			"category": "beer-wine",
-			"itemType": "Beer/Wine",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic"
-			]
-		},
-		{
-			"id": 101,
-			"name": "Peppermint Kiss",
-			"description": "Peppermint-infused Golden Eagle Vodka, Cr\u00e8me de Cacao, Cr\u00e8me de Menthe, Coco Lopez Coconut Cr\u00e8me, and house-made Frangelico whipped cream",
-			"location": "Disneyland Hotel",
-			"restaurant": "Broken Spell Lounge",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"peppermint"
-			]
-		},
-		{
-			"id": 102,
-			"name": "Prickly Pear French 75",
-			"description": "Condesa Prickly Pear Gin, St. George Spiced Pear Liqueur, Piper Sonoma Brut, honey, and lemon juice",
-			"location": "Disneyland Hotel",
-			"restaurant": "Broken Spell Lounge",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"cold"
-			]
-		},
-		{
-			"id": 103,
-			"name": "Thanksgiving Mule",
-			"description": "Tequila, Liquid Alchemist Ginger Syrup, cranberry sauce, celery salt, lime juice, and sage leaves",
-			"location": "Disneyland Hotel",
-			"restaurant": "Broken Spell Lounge",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"cranberry"
-			]
-		},
-		{
-			"id": 104,
-			"name": "Pumpkin Spice Latte",
-			"description": "Espresso, pumpkin spice syrup, and milk",
-			"location": "Disneyland Hotel",
-			"restaurant": "Goofy\u2019s Kitchen",
-			"price": null,
-			"category": "coffee-tea",
-			"itemType": "Coffee/Tea",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Goofys-Kitchen-1623x1080.jpg",
-			"tags": [
-				"non-alcoholic",
-				"new",
-				"pumpkin-spice",
-				"coffee-tea",
-				"cold",
-				"hot"
-			]
-		},
-		{
-			"id": 105,
-			"name": "Chai Ginger Latte",
-			"description": "Espresso, milk, chai syrup, white chocolate sauce, and gingerbread whipped cream",
-			"location": "Disneyland Hotel",
-			"restaurant": "Goofy\u2019s Kitchen",
-			"price": null,
-			"category": "coffee-tea",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"gingerbread",
-				"coffee-tea",
-				"cold",
-				"hot"
-			]
-		},
-		{
-			"id": 106,
-			"name": "Eggnog",
-			"description": "House-made eggnog",
-			"location": "Disneyland Hotel",
-			"restaurant": "Goofy\u2019s Kitchen",
-			"price": null,
-			"category": "non-alcoholic-beverage",
-			"itemType": "Non-Alcoholic Beverage",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"eggnog"
-			]
-		},
-		{
-			"id": 107,
-			"name": "Eggnog Latte",
-			"description": "House-made eggnog with two shots of espresso",
-			"location": "Disneyland Hotel",
-			"restaurant": "Goofy\u2019s Kitchen",
-			"price": null,
-			"category": "coffee-tea",
-			"itemType": "Coffee/Tea",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"eggnog",
-				"coffee-tea",
-				"cold",
-				"hot"
-			]
-		},
-		{
-			"id": 108,
-			"name": "Eggnog Cocktail",
-			"description": "House-made eggnog, Fonseca Bin 27 Port, Pierre Ferrand Cognac, and Smith & Cross Jamaican Pot Still Rum",
-			"location": "Disneyland Hotel",
-			"restaurant": "Goofy\u2019s Kitchen",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"eggnog"
-			]
-		},
-		{
-			"id": 109,
-			"name": "Mulled Wine",
-			"description": "The Fableist Wine Company The Silkworm and the Spider Pinot Noir with mulled spices, served over ice",
-			"location": "Disneyland Hotel",
-			"restaurant": "Goofy\u2019s Kitchen",
-			"price": null,
-			"category": "beer-wine",
-			"itemType": "Beer/Wine",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic"
-			]
-		},
-		{
-			"id": 110,
-			"name": "Mickey-shaped Gingerbread Cookie",
-			"description": "Soft gingerbread Mickey cookie with sprinkles",
-			"location": "Disneyland Hotel",
-			"restaurant": "The Coffee House",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Rice-Treat.jpg",
-			"tags": [
-				"gingerbread",
-				"character-themed",
-				"non-alcoholic"
-			]
-		},
-		{
-			"id": 111,
-			"name": "Mickey-shaped Holiday Cookie",
-			"description": "Shortbread cookie dipped in white chocolate with holiday sprinkles, and a chocolate Mickey decoration",
-			"location": "Disneyland Hotel",
-			"restaurant": "The Coffee House",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"character-themed",
-				"seasonal"
-			]
-		},
-		{
-			"id": 112,
-			"name": "Peppermint Crisped Rice Treat",
-			"description": "",
-			"location": "Disneyland Hotel",
-			"restaurant": "The Coffee House",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"peppermint"
-			]
-		},
-		{
-			"id": 113,
-			"name": "Cinnamon Roll Latte",
-			"description": "Espresso, milk, white chocolate sauce, brown sugar, cinnamon, and whipped cream",
-			"location": "Disneyland Hotel",
-			"restaurant": "The Coffee House",
-			"price": null,
-			"category": "coffee-tea",
-			"itemType": "Coffee/Tea",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"new",
-				"cinnamon",
-				"coffee-tea",
-				"cold",
-				"hot"
-			]
-		},
-		{
-			"id": 114,
-			"name": "Eggnog",
-			"description": "House-made eggnog",
-			"location": "Disneyland Hotel",
-			"restaurant": "The Coffee House",
-			"price": null,
-			"category": "non-alcoholic-beverage",
-			"itemType": "Non-Alcoholic Beverage",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"eggnog",
-				"cold",
-				"hot"
-			]
-		},
-		{
-			"id": 115,
-			"name": "Chai Ginger Latte",
-			"description": "Espresso, milk, chai syrup, white chocolate sauce, and gingerbread whipped cream",
-			"location": "Disneyland Hotel",
-			"restaurant": "The Coffee House",
-			"price": null,
-			"category": "coffee-tea",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"gingerbread",
-				"coffee-tea",
-				"cold",
-				"hot"
-			]
-		},
-		{
-			"id": 116,
-			"name": "Eggnog Latte",
-			"description": "House-made eggnog with a shot of espresso",
-			"location": "Disneyland Hotel",
-			"restaurant": "The Coffee House",
-			"price": null,
-			"category": "coffee-tea",
-			"itemType": "Coffee/Tea",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"eggnog",
-				"coffee-tea",
-				"cold",
-				"hot"
-			]
-		},
-		{
-			"id": 117,
-			"name": "Peppermint Mocha",
-			"description": "topped with whipped cream",
-			"location": "Disneyland Hotel",
-			"restaurant": "The Coffee House",
-			"price": null,
-			"category": "coffee-tea",
-			"itemType": "Coffee/Tea",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"peppermint",
-				"cold",
-				"hot"
-			]
-		},
-		{
-			"id": 118,
-			"name": "Pumpkin Spice Latte",
-			"description": "Espresso, pumpkin spice syrup, and milk",
-			"location": "Disneyland Hotel",
-			"restaurant": "The Coffee House",
-			"price": null,
-			"category": "coffee-tea",
-			"itemType": "Coffee/Tea",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"pumpkin-spice",
-				"coffee-tea",
-				"cold",
-				"hot"
-			]
-		},
-		{
-			"id": 119,
-			"name": "S\u2019mores Hot Chocolate",
-			"description": "topped with toasted marshmallow foam",
-			"location": "Disneyland Hotel",
-			"restaurant": "The Coffee House",
-			"price": null,
-			"category": "candy-snack",
-			"itemType": "Candy/Snack",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"hot"
-			]
-		},
-		{
-			"id": 120,
-			"name": "Crisp Nights",
-			"description": "Parrot Bay Coconut Rum, Tito\u2019s Handmade Vodka, lemon juice, and simple syrup",
-			"location": "Disneyland Hotel",
-			"restaurant": "Trader Sam\u2019s Enchanted Tiki Bar",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"new"
-			]
-		},
-		{
-			"id": 121,
-			"name": "Holichata",
-			"description": "Bacardi Reserva Ocho Rum, Frangelico Liqueur, St. Elizabeth Allspice Dram Liqueur, house-made Colibri mix, cinnamon syrup, and lemon juice",
-			"location": "Disneyland Hotel",
-			"restaurant": "Trader Sam\u2019s Enchanted Tiki Bar",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"new",
-				"cinnamon"
-			]
-		},
-		{
-			"id": 122,
-			"name": "Old Fashioned Joy",
-			"description": "Buffalo Trace Bourbon, Giffard\u2019s Banana Liqueur, maple syrup, and walnut bitters",
-			"location": "Disneyland Hotel",
-			"restaurant": "Trader Sam\u2019s Enchanted Tiki Bar",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"new",
-				"contains-nuts"
-			]
-		},
-		{
-			"id": 123,
-			"name": "Yuletide Cheers",
-			"description": "Zaya Rum, Avissi Prosecco, pomegranate and cranberry juices, and cinnamon syrup",
-			"location": "Disneyland Hotel",
-			"restaurant": "Trader Sam\u2019s Enchanted Tiki Bar",
-			"price": null,
-			"category": "beer-wine",
-			"itemType": "Beer/Wine",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"new",
-				"cranberry",
-				"cinnamon"
-			]
-		},
-		{
-			"id": 124,
-			"name": "Christmas Jumbo Cake Pop",
-			"description": "Chocolate cake pop dipped in white chocolate",
-			"location": "Disney\u2019s Grand Californian Hotel & Spa",
-			"restaurant": "Grand Californian Great Hall Cart",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Lights-Pop.jpg",
-			"tags": [
-				"non-alcoholic",
-				"new"
-			]
-		},
-		{
-			"id": 125,
-			"name": "Holiday Tea Cake Variety Box",
-			"description": "Vanilla Bean, Double Chocolate, Gingerbread, and Orange-cranberry individually wrapped tea cakes",
-			"location": "Disney\u2019s Grand Californian Hotel & Spa",
-			"restaurant": "Grand Californian Great Hall Cart",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"new",
-				"gingerbread",
-				"cranberry",
-				"seasonal",
-				"coffee-tea",
-				"non-alcoholic"
-			]
-		},
-		{
-			"id": 126,
-			"name": "Mickey Snowman Macaron",
-			"description": "",
-			"location": "Disney\u2019s Grand Californian Hotel & Spa",
-			"restaurant": "Grand Californian Great Hall Cart",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"new",
-				"character-themed"
-			]
-		},
-		{
-			"id": 127,
-			"name": "Raspberry Coconut Wreath",
-			"description": "Almond shortbread cookie with coconut macaron ring, filled with raspberry jam",
-			"location": "Disney\u2019s Grand Californian Hotel & Spa",
-			"restaurant": "Grand Californian Great Hall Cart",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"new",
-				"contains-nuts"
-			]
-		},
-		{
-			"id": 128,
-			"name": "Santa Jumbo Cake Pop",
-			"description": "Chocolate cake pop dipped in white chocolate",
-			"location": "Disney\u2019s Grand Californian Hotel & Spa",
-			"restaurant": "Grand Californian Great Hall Cart",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"new"
-			]
-		},
-		{
-			"id": 129,
-			"name": "Holiday Cookie Box",
-			"description": "Assorted cookies",
-			"location": "Disney\u2019s Grand Californian Hotel & Spa",
-			"restaurant": "Grand Californian Great Hall Cart",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"seasonal"
-			]
-		},
-		{
-			"id": 130,
-			"name": "Holiday Crisped Rice Treat",
-			"description": "",
-			"location": "Disney\u2019s Grand Californian Hotel & Spa",
-			"restaurant": "Grand Californian Great Hall Cart",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"seasonal"
-			]
-		},
-		{
-			"id": 131,
-			"name": "Mickey-shaped Gingerbread Cookie",
-			"description": "",
-			"location": "Disney\u2019s Grand Californian Hotel & Spa",
-			"restaurant": "Grand Californian Great Hall Cart",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"gingerbread",
-				"character-themed",
-				"non-alcoholic"
-			]
-		},
-		{
-			"id": 132,
-			"name": "Mickey-shaped Poinsettia Cookie",
-			"description": "",
-			"location": "Disney\u2019s Grand Californian Hotel & Spa",
-			"restaurant": "Grand Californian Great Hall Cart",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"character-themed"
-			]
-		},
-		{
-			"id": 133,
-			"name": "Seasonal Loaf Cake",
-			"description": "",
-			"location": "Disney\u2019s Grand Californian Hotel & Spa",
-			"restaurant": "Grand Californian Great Hall Cart",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic"
-			]
-		},
-		{
-			"id": 134,
-			"name": "Eggnog",
-			"description": "House-made eggnog (Also available with Bailey\u2019s Original Irish Cream Liqueur)",
-			"location": "Disney\u2019s Grand Californian Hotel & Spa",
-			"restaurant": "Grand Californian Great Hall Cart",
-			"price": null,
-			"category": "non-alcoholic-beverage",
-			"itemType": "Non-Alcoholic Beverage",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"eggnog"
-			]
-		},
-		{
-			"id": 135,
-			"name": "Hot Apple Cider",
-			"description": "",
-			"location": "Disney\u2019s Grand Californian Hotel & Spa",
-			"restaurant": "Grand Californian Great Hall Cart",
-			"price": null,
-			"category": "beer-wine",
-			"itemType": "Beer/Wine",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"apple",
-				"hot"
-			]
-		},
-		{
-			"id": 136,
-			"name": "Hot Chocolate",
-			"description": "House-made hot chocolate (Also available with Bailey\u2019s Original Irish Cream Liqueur)",
-			"location": "Disney\u2019s Grand Californian Hotel & Spa",
-			"restaurant": "Grand Californian Great Hall Cart",
-			"price": null,
-			"category": "candy-snack",
-			"itemType": "Candy/Snack",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"hot"
-			]
-		},
-		{
-			"id": 137,
-			"name": "Chocolate Peppermint Long John Donut",
-			"description": "",
-			"location": "Disney\u2019s Grand Californian Hotel & Spa",
-			"restaurant": "GCH Craftsman Grill",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"new",
-				"peppermint"
-			]
-		},
-		{
-			"id": 138,
-			"name": "Christmas Tree Cupcake",
-			"description": "",
-			"location": "Disney\u2019s Grand Californian Hotel & Spa",
-			"restaurant": "GCH Craftsman Grill",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"new"
-			]
-		},
-		{
-			"id": 139,
-			"name": "Cranberry Orange Muffin",
-			"description": "",
-			"location": "Disney\u2019s Grand Californian Hotel & Spa",
-			"restaurant": "GCH Craftsman Grill",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"new",
-				"cranberry"
-			]
-		},
-		{
-			"id": 140,
-			"name": "Eggnog Muffin",
-			"description": "",
-			"location": "Disney\u2019s Grand Californian Hotel & Spa",
-			"restaurant": "GCH Craftsman Grill",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"new",
-				"eggnog"
-			]
-		},
-		{
-			"id": 141,
-			"name": "Holiday Cake Donut",
-			"description": "",
-			"location": "Disney\u2019s Grand Californian Hotel & Spa",
-			"restaurant": "GCH Craftsman Grill",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"new",
-				"seasonal"
-			]
-		},
-		{
-			"id": 142,
-			"name": "Clark\u2019s Nutcracker",
-			"description": "Rum, lime juice, agave, cranberry, orange clove syrup, and cinnamon all served in a nutcracker glass",
-			"location": "Downtown Disney District",
-			"restaurant": "Vista Parkside Market",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Parkside-Market-1440x1080.jpg",
-			"tags": [
-				"alcoholic",
-				"new",
-				"cranberry",
-				"cinnamon"
-			]
-		},
-		{
-			"id": 143,
-			"name": "Fancy Bird",
-			"description": "Rye Scotch whisky, lime juice, orgeat, and orange cura\u00e7ao all served in a Vista Holiday Rocks glass",
-			"location": "Downtown Disney District",
-			"restaurant": "Vista Parkside Market",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"seasonal"
-			]
-		},
-		{
-			"id": 144,
-			"name": "Michael in a Pear Tree",
-			"description": "Tequila blanco, pear nectar, lime juice, and rosemary simple syrup all served in a bird glass",
-			"location": "Downtown Disney District",
-			"restaurant": "Vista Parkside Market",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"new"
-			]
-		},
-		{
-			"id": 145,
-			"name": "Scarlet Tanager",
-			"description": "Bourbon, amaro liqueur, orange-flavored liqueur, and cinnamon bitters all served in a Vista Holiday Rocks glass",
-			"location": "Downtown Disney District",
-			"restaurant": "Vista Parkside Market",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"new",
-				"cinnamon",
-				"seasonal"
-			]
-		},
-		{
-			"id": 146,
-			"name": "Peppermint Churro",
-			"description": "Churro rolled in peppermint powdered sugar, with a peppermint icing drizzled on top, and covered in crushed candy cane pieces",
-			"location": "Downtown Disney District",
-			"restaurant": "California Churro",
-			"price": null,
-			"category": "churro",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Peppermint-Churro.jpeg",
-			"tags": [
-				"non-alcoholic",
-				"new",
-				"peppermint"
-			]
-		},
-		{
-			"id": 147,
-			"name": "Three Course Christmas Dinner",
-			"description": "",
-			"location": "Downtown Disney District",
-			"restaurant": "Jazz Kitchen Coastal Grill & Patio",
-			"price": null,
-			"category": "entree",
-			"itemType": "Entree",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Christmas-Meal-810x1080.jpg",
-			"tags": [
-				"non-alcoholic",
-				"new",
-				"savory"
-			]
-		},
-		{
-			"id": 148,
-			"name": "Gingerbread Old Fashion",
-			"description": "Spirited blend of bourbon and gingerbread spice syrup",
-			"location": "Downtown Disney District",
-			"restaurant": "Jazz Kitchen Coastal Grill & Patio",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"new",
-				"gingerbread"
-			]
-		},
-		{
-			"id": 149,
-			"name": "Candy Cane Twist Glazed Beignet",
-			"description": "Beignet coated in a frosty peppermint glaze with crushed green candy",
-			"location": "Downtown Disney District",
-			"restaurant": "Beignets Expressed",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Holiday-Beignet-810x1080.jpg",
-			"tags": [
-				"non-alcoholic",
-				"peppermint"
-			]
-		},
-		{
-			"id": 150,
-			"name": "Seasonal Mini Cheesecakes",
-			"description": "including Peppermint Chocolate, Pumpkin Spice, Mango, and Strawberry",
-			"location": "Downtown Disney District",
-			"restaurant": "Splitsville Luxury Lanes",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"pumpkin-spice",
-				"peppermint"
-			]
-		},
-		{
-			"id": 151,
-			"name": "White Christmas Margarita",
-			"description": "Tequila, coconut milk, lime juice, and orange liqueur topped with rosemary and cranberries",
-			"location": "Downtown Disney District",
-			"restaurant": "Splitsville Luxury Lanes",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic"
-			]
-		},
-		{
-			"id": 152,
-			"name": "Tamal de Rajas",
-			"description": "Corn husk tamal, rajas, Mexican cheese blend, and pickled jalape\u00f1os, carrots and squash veggies",
-			"location": "Downtown Disney District",
-			"restaurant": "C\u00e9ntrico",
-			"price": null,
-			"category": "entree",
-			"itemType": "Entree",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Chicken-Tamal.jpg",
-			"tags": [
-				"non-alcoholic",
-				"new"
-			]
-		},
-		{
-			"id": 153,
-			"name": "Mexican Hot Chocolate",
-			"description": "A rich, velvety hot chocolate served in the style of traditional Mexican \u201cchocolate para mesa\u201d \u2014 thick, luscious and spiced",
-			"location": "Downtown Disney District",
-			"restaurant": "C\u00e9ntrico",
-			"price": null,
-			"category": "candy-snack",
-			"itemType": "Candy/Snack",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"new",
-				"cold",
-				"hot"
-			]
-		},
-		{
-			"id": 154,
-			"name": "Berry MexMas",
-			"description": "Tequila reposado, black cherry, and lime juice",
-			"location": "Downtown Disney District",
-			"restaurant": "C\u00e9ntrico",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"new"
-			]
-		},
-		{
-			"id": 155,
-			"name": "Frosty Fiesta",
-			"description": "Horchata cream liquor, rum, cinnamon whiskey, and horchata",
-			"location": "Downtown Disney District",
-			"restaurant": "C\u00e9ntrico",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"new",
-				"cinnamon"
-			]
-		},
-		{
-			"id": 156,
-			"name": "Holiday Bu\u00f1uelo",
-			"description": "with holiday sugar candy and orange cinnamon sugar",
-			"location": "Downtown Disney District",
-			"restaurant": "Tiendita",
-			"price": null,
-			"category": "candy-snack",
-			"itemType": "Candy/Snack",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Cornish-Hen.jpg",
-			"tags": [
-				"non-alcoholic",
-				"cinnamon",
-				"seasonal"
-			]
-		},
-		{
-			"id": 157,
-			"name": "Tis\u2019 the season for Pizza Bitz!",
-			"description": "Buttery pretzel bitz, rolled in cheese, and adorned with a pepperoni slice",
-			"location": "Downtown Disney District",
-			"restaurant": "Wetzel\u2019s Pretzels",
-			"price": null,
-			"category": "savory-snack",
-			"itemType": "Savory Snack",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Prime-Rib.jpg",
-			"tags": [
-				"non-alcoholic"
-			]
-		},
-		{
-			"id": 158,
-			"name": "Christmas Cider",
-			"description": "Peanut butter whiskey, apple cider, hibiscus tea with edible glitter, lemon juice",
-			"location": "Downtown Disney District",
-			"restaurant": "Naples Ristorante e Bar",
-			"price": null,
-			"category": "beer-wine",
-			"itemType": "Beer/Wine",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Pizza.jpg",
-			"tags": [
-				"alcoholic",
-				"new",
-				"apple",
-				"coffee-tea"
-			]
-		},
-		{
-			"id": 159,
-			"name": "Santa\u2019s Margarita",
-			"description": "Tequila blanco, peach schnapps, margarita mix, cranberry juice, and black raspberry liquor",
-			"location": "Downtown Disney District",
-			"restaurant": "Naples Ristorante e Bar",
-			"price": null,
-			"category": "cocktail",
-			"itemType": "Cocktail",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"new",
-				"cranberry"
-			]
-		},
-		{
-			"id": 160,
-			"name": "Twisted Christmas Cider",
-			"description": "Peanut butter whiskey, apple cider, hibiscus team, edible glitter, and lemon juice",
-			"location": "Downtown Disney District",
-			"restaurant": "Naples Ristorante e Bar",
-			"price": null,
-			"category": "beer-wine",
-			"itemType": "Beer/Wine",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"alcoholic",
-				"new",
-				"apple",
-				"coffee-tea"
-			]
-		},
-		{
-			"id": 161,
-			"name": "Chocolate Spice Macaron Croissant",
-			"description": "Flaky butter croissant filled with silky chocolate custard infused with holiday spices, finished with delicate macaron shell",
-			"location": "Downtown Disney District",
-			"restaurant": "Kayla\u2019s Cake",
-			"price": null,
-			"category": "baked-dessert",
-			"itemType": "Baked Dessert",
-			"mobileOrderAvailable": false,
-			"availability": {
-				"startDate": "2025-11-14",
-				"endDate": "2026-01-07"
-			},
-			"imageUrl": null,
-			"tags": [
-				"non-alcoholic",
-				"new",
-				"seasonal"
-			]
-		}
-	]
+  "metadata": {
+    "generatedAt": "2025-11-22T07:47:48.628Z",
+    "totalItems": 166,
+    "dataSource": "Disneyland Holiday 2025 Food Guide",
+    "filters": {
+      "locations": [
+        "California Adventure",
+        "Disneyland",
+        "Disneyland Hotel",
+        "Disney’s Grand Californian Hotel & Spa",
+        "Downtown Disney District"
+      ],
+      "restaurants": [
+        "Alien Pizza Planet",
+        "Bayside Brews",
+        "Beignets Expressed",
+        "Bengal Barbecue",
+        "Blue Bayou Restaurant",
+        "Boudin Bread Cart",
+        "Broken Spell Lounge",
+        "Cafe Orleans",
+        "Café Daisy",
+        "California Churro",
+        "Carnation Café",
+        "Churros near Big Thunder Mountain Railroad and Pretzels near Big Thunder Mountain Railroad",
+        "Churros near Casey Jr. Circus Train",
+        "Churros near Redwood Creek Challenge Trail",
+        "Churros near Town Square and Sleeping Beauty Castle",
+        "Clarabelle’s Hand-Scooped Ice Cream",
+        "Corn Dog Castle",
+        "Cozy Cone Motel 1 – Churros",
+        "Cozy Cone Motel 2 – Ice Cream Cones",
+        "Céntrico",
+        "Edelweiss Snacks",
+        "Flo’s V8 Cafe",
+        "GCH Craftsman Grill",
+        "Galactic Grill",
+        "Ghirardelli Soda Fountain and Chocolate Shop",
+        "Good Boy! Grocers",
+        "Goofy’s Kitchen",
+        "Grand Californian Great Hall Cart",
+        "Hollywood Lounge",
+        "Jazz Kitchen Coastal Grill & Patio",
+        "Jolly Holiday Bakery Cafe",
+        "Kayla’s Cake",
+        "Lamplight Lounge",
+        "Lamplight Lounge – Boardwalk Dining",
+        "Little Red Wagon",
+        "Lucky Fortune Cookery",
+        "Mint Julep Bar",
+        "Mortimers Market",
+        "Naples Ristorante e Bar",
+        "Popcorn near Haunted Mansion",
+        "Pretzels at small world Promenade",
+        "Pretzels near Star Tours – The Adventures Continue",
+        "Pym Test Kitchen",
+        "Rancho del Zocalo Restaurante",
+        "Refreshment Corner",
+        "River Belle Terrace",
+        "Royal Street Veranda",
+        "Smokejumpers Grill",
+        "Splitsville Luxury Lanes",
+        "Stage Door Café",
+        "Studio Catering Co.",
+        "The Coffee House",
+        "The Golden Horseshoe",
+        "Tiendita",
+        "Trader Sam’s Enchanted Tiki Bar",
+        "Troubadour Tavern",
+        "Vista Parkside Market",
+        "Wetzel’s Pretzels",
+        "Willie’s Churros at Buena Vista Street",
+        "Wine Country Trattoria"
+      ],
+      "categories": [
+        "baked-dessert",
+        "beer-wine",
+        "candy-snack",
+        "churro",
+        "cocktail",
+        "coffee-tea",
+        "entree",
+        "frozen-dessert",
+        "non-alcoholic-beverage",
+        "salad",
+        "savory-snack"
+      ],
+      "allTags": [
+        "alcoholic",
+        "apple",
+        "character-themed",
+        "cinnamon",
+        "coffee-tea",
+        "cold",
+        "contains-nuts",
+        "cranberry",
+        "eggnog",
+        "gingerbread",
+        "hot",
+        "new",
+        "non-alcoholic",
+        "peppermint",
+        "plant-based",
+        "pumpkin-spice",
+        "savory",
+        "seasonal",
+        "vegan"
+      ]
+    }
+  },
+  "items": [
+    {
+      "id": 1,
+      "name": "Holiday Dinner Special",
+      "description": "Petite New York medallions, herbed Yukon Gold mashed potatoes, haricots verts, onion straws, and cabernet demi-glace",
+      "location": "Disneyland",
+      "restaurant": "Carnation Café",
+      "price": null,
+      "category": "entree",
+      "itemType": "Entree",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-12-01",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Holiday-Dinner.jpg",
+      "tags": [
+        "non-alcoholic",
+        "seasonal",
+        "savory"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "Cosmopolitan",
+      "description": "Tito’s Handmade Vodka, Cointreau, and cranberry and lime juices",
+      "location": "Disneyland",
+      "restaurant": "Carnation Café",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "cranberry"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "Eggnog Old Fashioned",
+      "description": "Buffalo Trace Bourbon, bitters, orange-infused brown sugar syrup, and candied orange peel topped with eggnog cream",
+      "location": "Disneyland",
+      "restaurant": "Carnation Café",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Old-Fashioned.jpg",
+      "tags": [
+        "alcoholic",
+        "eggnog"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "Apple Pie Dipping Sauce",
+      "description": "Cream cheese frosting topped with spiced apple compote",
+      "location": "Disneyland",
+      "restaurant": "Churros near Town Square and Sleeping Beauty Castle",
+      "price": null,
+      "category": "churro",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Apple-Dip.jpg",
+      "tags": [
+        "non-alcoholic",
+        "new",
+        "apple",
+        "cold"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "Gingerbread-Cranberry Cheesecake Trifle",
+      "description": "Layers of gingerbread cake, cheesecake, and cranberry compote topped with gingerbread crunch, white chocolate mousse, and a mini gingerbread man",
+      "location": "Disneyland",
+      "restaurant": "Jolly Holiday Bakery Cafe",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Cheesecake-Trifle.jpg",
+      "tags": [
+        "new",
+        "gingerbread",
+        "cranberry",
+        "non-alcoholic"
+      ]
+    },
+    {
+      "id": 6,
+      "name": "Orange-Cranberry Loaf",
+      "description": "topped with cream cheese glaze and dried cranberries drizzled with white chocolate",
+      "location": "Disneyland",
+      "restaurant": "Jolly Holiday Bakery Cafe",
+      "price": null,
+      "category": "candy-snack",
+      "itemType": "Candy/Snack",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Orange-Loaf.jpg",
+      "tags": [
+        "non-alcoholic",
+        "new",
+        "cranberry"
+      ]
+    },
+    {
+      "id": 7,
+      "name": "S'mores Cheesecake",
+      "description": "Chocolate cheesecake with chocolate ganache topped with marshmallow mousse and a torched marshmallow",
+      "location": "Disneyland",
+      "restaurant": "Jolly Holiday Bakery Cafe",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Smores-Cheesecake.jpg",
+      "tags": [
+        "non-alcoholic",
+        "new"
+      ]
+    },
+    {
+      "id": 8,
+      "name": "Sticky Toffee Bundt Cake",
+      "description": "with toffee sauce topped with vanilla chantilly cream",
+      "location": "Disneyland",
+      "restaurant": "Jolly Holiday Bakery Cafe",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Bundt-Cake.jpg",
+      "tags": [
+        "non-alcoholic",
+        "new"
+      ]
+    },
+    {
+      "id": 9,
+      "name": "White Mocha-Peppermint Tree-shaped Macaron",
+      "description": "filled with peppermint buttercream and a coffee bundt cake center",
+      "location": "Disneyland",
+      "restaurant": "Jolly Holiday Bakery Cafe",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-12-14"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Tree-Macaron.jpg",
+      "tags": [
+        "non-alcoholic",
+        "new",
+        "peppermint",
+        "coffee-tea"
+      ]
+    },
+    {
+      "id": 10,
+      "name": "Mickey Gingerbread",
+      "description": "Soft gingerbread Mickey cookie (Limit five per person, per transaction)",
+      "location": "Disneyland",
+      "restaurant": "Jolly Holiday Bakery Cafe",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Mickey-Gingerbread.jpg",
+      "tags": [
+        "gingerbread",
+        "character-themed",
+        "non-alcoholic"
+      ]
+    },
+    {
+      "id": 11,
+      "name": "Mickey-shaped Holiday Cookie",
+      "description": "Shortbread cookie dipped in white chocolate with holiday sprinkles, and a chocolate Mickey decoration",
+      "location": "Disneyland",
+      "restaurant": "Jolly Holiday Bakery Cafe",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Mickey-Cookie.jpg",
+      "tags": [
+        "non-alcoholic",
+        "character-themed",
+        "seasonal"
+      ]
+    },
+    {
+      "id": 12,
+      "name": "Pumpkin Muffin",
+      "description": "topped with cream cheese icing",
+      "location": "Disneyland",
+      "restaurant": "Jolly Holiday Bakery Cafe",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "pumpkin-spice"
+      ]
+    },
+    {
+      "id": 13,
+      "name": "Peppermint Cold Brew",
+      "description": "topped with vanilla foam and holiday sugar",
+      "location": "Disneyland",
+      "restaurant": "Jolly Holiday Bakery Cafe",
+      "price": null,
+      "category": "coffee-tea",
+      "itemType": "Coffee/Tea",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Peppermint-Cold-Brew.jpg",
+      "tags": [
+        "non-alcoholic",
+        "peppermint",
+        "seasonal",
+        "cold"
+      ]
+    },
+    {
+      "id": 14,
+      "name": "Chili Cheese Corn Dog",
+      "description": "Classic corn dog topped with spicy chili, jalapeño-cilantro crema, cheddar cheese, and crispy onions served with choice of Cuties Mandarin Orange or potato chips",
+      "location": "Disneyland",
+      "restaurant": "Little Red Wagon",
+      "price": null,
+      "category": "savory-snack",
+      "itemType": "Savory Snack",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Corn-Dog.jpg",
+      "tags": [
+        "non-alcoholic",
+        "character-themed"
+      ]
+    },
+    {
+      "id": 15,
+      "name": "Blood Orange & Hibiscus Limeade",
+      "description": "garnished with dried fruit",
+      "location": "Disneyland",
+      "restaurant": "Little Red Wagon",
+      "price": null,
+      "category": "non-alcoholic-beverage",
+      "itemType": "Non-Alcoholic Beverage",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Orange-Lemonade.jpg",
+      "tags": [
+        "non-alcoholic"
+      ]
+    },
+    {
+      "id": 16,
+      "name": "Warm Spiced Apple Tea",
+      "description": "with hints of cinnamon and clove topped with vanilla cream foam",
+      "location": "Disneyland",
+      "restaurant": "Refreshment Corner",
+      "price": null,
+      "category": "coffee-tea",
+      "itemType": "Coffee/Tea",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Philly-Potato.jpg",
+      "tags": [
+        "non-alcoholic",
+        "apple",
+        "cinnamon",
+        "coffee-tea",
+        "cold",
+        "hot"
+      ]
+    },
+    {
+      "id": 17,
+      "name": "Vietnamese Iced Coffee",
+      "description": "with brown sugar spheres and cold foam",
+      "location": "Disneyland",
+      "restaurant": "Bengal Barbecue",
+      "price": null,
+      "category": "coffee-tea",
+      "itemType": "Coffee/Tea",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Vietnamese-Coffee.jpg",
+      "tags": [
+        "non-alcoholic",
+        "new",
+        "coffee-tea",
+        "cold"
+      ]
+    },
+    {
+      "id": 18,
+      "name": "Iced Pandan Cooler",
+      "description": "with brown sugar spheres and ube cold foam",
+      "location": "Disneyland",
+      "restaurant": "Bengal Barbecue",
+      "price": null,
+      "category": "non-alcoholic-beverage",
+      "itemType": "Non-Alcoholic Beverage",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Pandan-Cooler.jpg",
+      "tags": [
+        "non-alcoholic",
+        "cold"
+      ]
+    },
+    {
+      "id": 19,
+      "name": "Chocolate Peppermint Dipping Sauce",
+      "description": "",
+      "location": "Disneyland",
+      "restaurant": "Churros near Big Thunder Mountain Railroad and Pretzels near Big Thunder Mountain Railroad",
+      "price": null,
+      "category": "churro",
+      "itemType": "Candy/Snack",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Peppermint-Dip.jpg",
+      "tags": [
+        "non-alcoholic",
+        "new",
+        "peppermint"
+      ]
+    },
+    {
+      "id": 20,
+      "name": "Chocolate Cake Flan",
+      "description": "Chocolate cake and flan topped with caramel sauce, whipped cream, and cinnamon dust",
+      "location": "Disneyland",
+      "restaurant": "Rancho del Zocalo Restaurante",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Chocolate-Flan.jpg",
+      "tags": [
+        "non-alcoholic",
+        "cinnamon"
+      ]
+    },
+    {
+      "id": 21,
+      "name": "Hibiscus-Pomegranate Cooler",
+      "description": "Spiced hibiscus tea, pomegranate and orange juices, and honey",
+      "location": "Disneyland",
+      "restaurant": "Rancho del Zocalo Restaurante",
+      "price": null,
+      "category": "non-alcoholic-beverage",
+      "itemType": "Coffee/Tea",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Pomegranate-Cooler.jpg",
+      "tags": [
+        "non-alcoholic",
+        "coffee-tea",
+        "cold"
+      ]
+    },
+    {
+      "id": 22,
+      "name": "Sticky Toffee Pudding",
+      "description": "Vanilla pudding, sticky toffee cake, and candy pecans",
+      "location": "Disneyland",
+      "restaurant": "River Belle Terrace",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Chess-Pie.jpg",
+      "tags": [
+        "non-alcoholic",
+        "contains-nuts"
+      ]
+    },
+    {
+      "id": 23,
+      "name": "Wreath Funnel Cake",
+      "description": "Green funnel cake with caramel sauce, apple filling, whipped topping, and holiday sprinkles",
+      "location": "Disneyland",
+      "restaurant": "Stage Door Café",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Funnel-Cake.jpg",
+      "tags": [
+        "non-alcoholic",
+        "apple",
+        "seasonal"
+      ]
+    },
+    {
+      "id": 24,
+      "name": "Gingerbread Sundae",
+      "description": "Gingerbread cake with vanilla ice cream and whipped topping",
+      "location": "Disneyland",
+      "restaurant": "The Golden Horseshoe",
+      "price": null,
+      "category": "frozen-dessert",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "gingerbread",
+        "non-alcoholic"
+      ]
+    },
+    {
+      "id": 25,
+      "name": "Sticky Toffee Cake",
+      "description": "soaked in bourbon toffee sauce and garnished with candied walnuts and vanilla ice cream",
+      "location": "Disneyland",
+      "restaurant": "Blue Bayou Restaurant",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Toffee-Cake.jpg",
+      "tags": [
+        "new",
+        "contains-nuts",
+        "non-alcoholic"
+      ]
+    },
+    {
+      "id": 26,
+      "name": "Roasted Beet and Citrus Salad",
+      "description": "Crema, herbs, almonds, fennel, and poppy seed vinaigrette",
+      "location": "Disneyland",
+      "restaurant": "Blue Bayou Restaurant",
+      "price": null,
+      "category": "salad",
+      "itemType": "Salad",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "plant-based",
+        "vegan",
+        "contains-nuts"
+      ]
+    },
+    {
+      "id": 27,
+      "name": "Holiday Sangria",
+      "description": "Cocktail-inspired seltzer with cinnamon",
+      "location": "Disneyland",
+      "restaurant": "Blue Bayou Restaurant",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "new",
+        "cinnamon",
+        "seasonal"
+      ]
+    },
+    {
+      "id": 28,
+      "name": "Cherry Cream Soda",
+      "description": "Sprite, cherry syrup, and cream",
+      "location": "Disneyland",
+      "restaurant": "Cafe Orleans",
+      "price": null,
+      "category": "non-alcoholic-beverage",
+      "itemType": "Non-Alcoholic Beverage",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic"
+      ]
+    },
+    {
+      "id": 29,
+      "name": "Holiday Sangria",
+      "description": "Cocktail-inspired seltzer with cinnamon",
+      "location": "Disneyland",
+      "restaurant": "Cafe Orleans",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "new",
+        "cinnamon",
+        "seasonal"
+      ]
+    },
+    {
+      "id": 30,
+      "name": "Peppermint Mickey-shaped Beignets",
+      "description": "dusted in peppermint powdered sugar",
+      "location": "Disneyland",
+      "restaurant": "Mint Julep Bar",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Beignets.jpg",
+      "tags": [
+        "non-alcoholic",
+        "peppermint",
+        "character-themed"
+      ]
+    },
+    {
+      "id": 31,
+      "name": "Whipped Chocolate-Peppermint Dip",
+      "description": "",
+      "location": "Disneyland",
+      "restaurant": "Mint Julep Bar",
+      "price": null,
+      "category": "candy-snack",
+      "itemType": "Candy/Snack",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Peppermint-Dip-1.jpg",
+      "tags": [
+        "non-alcoholic",
+        "peppermint"
+      ]
+    },
+    {
+      "id": 32,
+      "name": "Cranberry-Pomegranate Mint Julep",
+      "description": "with mixed berry-flavored popping spheres",
+      "location": "Disneyland",
+      "restaurant": "Mint Julep Bar",
+      "price": null,
+      "category": "non-alcoholic-beverage",
+      "itemType": "Non-Alcoholic Beverage",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Cranberry-Julep.jpg",
+      "tags": [
+        "non-alcoholic",
+        "cranberry"
+      ]
+    },
+    {
+      "id": 33,
+      "name": "Holiday Treats Mix-in",
+      "description": "Add on a scoop of holiday candy mix to classic buttery popcorn, complete with red and green M&M'S Milk Chocolate Candies and mini marshmallows",
+      "location": "Disneyland",
+      "restaurant": "Popcorn near Haunted Mansion",
+      "price": null,
+      "category": "savory-snack",
+      "itemType": "Savory Snack",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Holiday-Popcorn.jpg",
+      "tags": [
+        "non-alcoholic",
+        "seasonal"
+      ]
+    },
+    {
+      "id": 34,
+      "name": "Roasted Vegetable Salad",
+      "description": "Roasted Brussels sprouts, beets, butternut squash, yams, and burrata cheese with herbed balsamic vinaigrette",
+      "location": "Disneyland",
+      "restaurant": "Royal Street Veranda",
+      "price": null,
+      "category": "salad",
+      "itemType": "Salad",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Vegetable-Salad.jpg",
+      "tags": [
+        "non-alcoholic"
+      ]
+    },
+    {
+      "id": 35,
+      "name": "Coffee Fritters",
+      "description": "rolled in cinnamon sugar, drizzled with white mocha sauce, and garnished with praline sugar streusel",
+      "location": "Disneyland",
+      "restaurant": "Royal Street Veranda",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Coffee/Tea",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Coffee-Fritters.jpg",
+      "tags": [
+        "non-alcoholic",
+        "cinnamon",
+        "coffee-tea"
+      ]
+    },
+    {
+      "id": 36,
+      "name": "Hot Spiced Apple Cider",
+      "description": "topped with caramel whipped cream",
+      "location": "Disneyland",
+      "restaurant": "Royal Street Veranda",
+      "price": null,
+      "category": "beer-wine",
+      "itemType": "Beer/Wine",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Apple-Cider.jpg",
+      "tags": [
+        "non-alcoholic",
+        "new",
+        "apple",
+        "cold",
+        "hot"
+      ]
+    },
+    {
+      "id": 37,
+      "name": "Gingerbread Churro",
+      "description": "Classic churro rolled in gingerbread sugar dust",
+      "location": "Disneyland",
+      "restaurant": "Churros near Casey Jr. Circus Train",
+      "price": null,
+      "category": "churro",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Stew.jpg",
+      "tags": [
+        "gingerbread",
+        "non-alcoholic"
+      ]
+    },
+    {
+      "id": 38,
+      "name": "Butterscotch Dipping Sauce",
+      "description": "Butterscotch caramel dip",
+      "location": "Disneyland",
+      "restaurant": "Churros near Casey Jr. Circus Train",
+      "price": null,
+      "category": "churro",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic"
+      ]
+    },
+    {
+      "id": 39,
+      "name": "Black Forest Cake",
+      "description": "Chocolate sponge cake filled with cherries and topped with chocolate ganache, chantilly crème, chocolate curls, cherries, and powdered sugar",
+      "location": "Disneyland",
+      "restaurant": "Edelweiss Snacks",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic"
+      ]
+    },
+    {
+      "id": 40,
+      "name": "Butterscotch Dipping Sauce",
+      "description": "Butterscotch caramel dip",
+      "location": "Disneyland",
+      "restaurant": "Pretzels at small world Promenade",
+      "price": null,
+      "category": "churro",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic"
+      ]
+    },
+    {
+      "id": 41,
+      "name": "Daisy’s Goody-Goody Donuts",
+      "description": "House-made mini apple cider donuts with spiced apple sugar",
+      "location": "Disneyland",
+      "restaurant": "Café Daisy",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Apple-Donuts.jpg",
+      "tags": [
+        "apple",
+        "character-themed",
+        "cold",
+        "non-alcoholic"
+      ]
+    },
+    {
+      "id": 42,
+      "name": "Very Merry Cran-Peary",
+      "description": "Minute Maid Zero Sugar Lemonade with cranberry and pear syrups garnished with cranberries and a fresh rosemary sprig",
+      "location": "Disneyland",
+      "restaurant": "Café Daisy",
+      "price": null,
+      "category": "non-alcoholic-beverage",
+      "itemType": "Non-Alcoholic Beverage",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Daisy-Cranberry.jpg",
+      "tags": [
+        "non-alcoholic",
+        "cranberry"
+      ]
+    },
+    {
+      "id": 43,
+      "name": "Strawberry Slushie with Fanta S",
+      "description": "trawberry (Also available with Orb Sipper)",
+      "location": "Disneyland",
+      "restaurant": "Good Boy! Grocers",
+      "price": null,
+      "category": "non-alcoholic-beverage",
+      "itemType": "Non-Alcoholic Beverage",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "new"
+      ]
+    },
+    {
+      "id": 44,
+      "name": "Claw-sagna Pasta",
+      "description": "Campanelle pasta tossed in ricotta and mozzarella sauce, topped with bolognese sauce and garnished with toasted breadcrumbs, parmesan, and basil",
+      "location": "Disneyland",
+      "restaurant": "Alien Pizza Planet",
+      "price": null,
+      "category": "entree",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Pasta.jpg",
+      "tags": [
+        "non-alcoholic"
+      ]
+    },
+    {
+      "id": 45,
+      "name": "Apple and Pecan Salad",
+      "description": "Mixed greens with frisée, candied pecans, Granny Smith apple, feta crumbles, and maple dressing",
+      "location": "Disneyland",
+      "restaurant": "Alien Pizza Planet",
+      "price": null,
+      "category": "salad",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "apple",
+        "contains-nuts",
+        "non-alcoholic"
+      ]
+    },
+    {
+      "id": 46,
+      "name": "Alien Reindeer Macarooooon",
+      "description": "filled with salted caramel buttercream, chocolate ganache, and brownie pieces",
+      "location": "Disneyland",
+      "restaurant": "Alien Pizza Planet",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Reindeer-Macaron.jpg",
+      "tags": [
+        "non-alcoholic"
+      ]
+    },
+    {
+      "id": 47,
+      "name": "Holiday Green Drink",
+      "description": "Apple-flavored beverage topped with caramel cold foam and sprinkles",
+      "location": "Disneyland",
+      "restaurant": "Alien Pizza Planet",
+      "price": null,
+      "category": "candy-snack",
+      "itemType": "Candy/Snack",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Green-Drink.jpg",
+      "tags": [
+        "non-alcoholic",
+        "apple",
+        "seasonal",
+        "cold"
+      ]
+    },
+    {
+      "id": 48,
+      "name": "Holiday Parfait",
+      "description": "Layers of chocolate cake, edible cookie dough, marshmallow mousse, chocolate crunch, chocolate mousse, and ganache finished with colored mousse, star glitter, and truffle shell",
+      "location": "Disneyland",
+      "restaurant": "Galactic Grill",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Holiday-Parfait.jpg",
+      "tags": [
+        "non-alcoholic",
+        "new",
+        "seasonal"
+      ]
+    },
+    {
+      "id": 49,
+      "name": "Holiday Punch",
+      "description": "Pomegranate, cranberry, and orange juices and Sprite, garnished with cranberries, orange wedge, and a rosemary sprig",
+      "location": "Disneyland",
+      "restaurant": "Galactic Grill",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Christmas-Punch.jpg",
+      "tags": [
+        "non-alcoholic",
+        "cranberry",
+        "seasonal"
+      ]
+    },
+    {
+      "id": 50,
+      "name": "Holiday Chocolate Foam Cold Brew",
+      "description": "Joffrey's Cold Brew Coffee with a splash of hazelnut syrup, topped with hot chocolate foam and garnished with cinnamon-flavored cereal",
+      "location": "Disneyland",
+      "restaurant": "Galactic Grill",
+      "price": null,
+      "category": "coffee-tea",
+      "itemType": "Coffee/Tea",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Chocolate-Cold-Brew.jpg",
+      "tags": [
+        "non-alcoholic",
+        "cinnamon",
+        "seasonal",
+        "coffee-tea",
+        "cold",
+        "hot",
+        "contains-nuts"
+      ]
+    },
+    {
+      "id": 51,
+      "name": "Toffee Pretzel",
+      "description": "Cream cheese-filled pretzel with toffee sugar",
+      "location": "Disneyland",
+      "restaurant": "Pretzels near Star Tours – The Adventures Continue",
+      "price": null,
+      "category": "candy-snack",
+      "itemType": "Savory Snack",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Toffee-Pretzel.jpg",
+      "tags": [
+        "non-alcoholic"
+      ]
+    },
+    {
+      "id": 52,
+      "name": "Chocolate-Peppermint Sundae",
+      "description": "Chocolate and peppermint ice cream in a waffle cup, topped with whipped cream and peppermint candy",
+      "location": "California Adventure",
+      "restaurant": "Clarabelle’s Hand-Scooped Ice Cream",
+      "price": null,
+      "category": "frozen-dessert",
+      "itemType": "Frozen Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Peppermint-Sundae.jpg",
+      "tags": [
+        "non-alcoholic",
+        "peppermint"
+      ]
+    },
+    {
+      "id": 53,
+      "name": "Peppermint Ice Cream",
+      "description": "",
+      "location": "California Adventure",
+      "restaurant": "Clarabelle’s Hand-Scooped Ice Cream",
+      "price": null,
+      "category": "frozen-dessert",
+      "itemType": "Frozen Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "peppermint"
+      ]
+    },
+    {
+      "id": 54,
+      "name": "Christmas Tree Pull-apart Sourdough Bread",
+      "description": "",
+      "location": "California Adventure",
+      "restaurant": "Mortimers Market",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Sourdough-Tree.jpg",
+      "tags": [
+        "non-alcoholic",
+        "plant-based",
+        "vegan"
+      ]
+    },
+    {
+      "id": 55,
+      "name": "Carrot Cake Churro",
+      "description": "Classic churro topped with carrot cake pieces and cream cheese",
+      "location": "California Adventure",
+      "restaurant": "Willie's Churros at Buena Vista Street",
+      "price": null,
+      "category": "churro",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Carrot-Churro.jpg",
+      "tags": [
+        "non-alcoholic"
+      ]
+    },
+    {
+      "id": 56,
+      "name": "Apple-Tamarind Agua Fresca",
+      "description": "garnished with a dried apple slide",
+      "location": "California Adventure",
+      "restaurant": "Hollywood Lounge",
+      "price": null,
+      "category": "non-alcoholic-beverage",
+      "itemType": "Non-Alcoholic Beverage",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Agua-Fresca.jpg",
+      "tags": [
+        "non-alcoholic",
+        "new",
+        "apple"
+      ]
+    },
+    {
+      "id": 57,
+      "name": "Brooklyn Brewery Brown Ale",
+      "description": "",
+      "location": "California Adventure",
+      "restaurant": "Hollywood Lounge",
+      "price": null,
+      "category": "beer-wine",
+      "itemType": "Beer/Wine",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "new"
+      ]
+    },
+    {
+      "id": 58,
+      "name": "Spiced Pomegranate Cocktail",
+      "description": "",
+      "location": "California Adventure",
+      "restaurant": "Hollywood Lounge",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Pomegranate-Cocktail.jpg",
+      "tags": [
+        "non-alcoholic",
+        "new",
+        "cold"
+      ]
+    },
+    {
+      "id": 59,
+      "name": "Study Break Beverage Company Cranberry Mule",
+      "description": "",
+      "location": "California Adventure",
+      "restaurant": "Hollywood Lounge",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Cranberry-Mule.jpg",
+      "tags": [
+        "alcoholic",
+        "new",
+        "cranberry"
+      ]
+    },
+    {
+      "id": 60,
+      "name": "Unsung Brewing Company Blood Orange Seltzer",
+      "description": "",
+      "location": "California Adventure",
+      "restaurant": "Hollywood Lounge",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Orange-Seltzer.jpg",
+      "tags": [
+        "alcoholic",
+        "new"
+      ]
+    },
+    {
+      "id": 61,
+      "name": "Seaborn Cocktails CranMerry Lime Margarita",
+      "description": "",
+      "location": "California Adventure",
+      "restaurant": "Hollywood Lounge",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic"
+      ]
+    },
+    {
+      "id": 62,
+      "name": "Apple-Tamarind Agua Fresca",
+      "description": "garnished with a dried apple slide",
+      "location": "California Adventure",
+      "restaurant": "Studio Catering Co.",
+      "price": null,
+      "category": "non-alcoholic-beverage",
+      "itemType": "Non-Alcoholic Beverage",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Agua-Fresca.jpg",
+      "tags": [
+        "non-alcoholic",
+        "new",
+        "apple"
+      ]
+    },
+    {
+      "id": 63,
+      "name": "Asgardian Apple Cold Brew",
+      "description": "Caramel cold brew, green apple cold foam, and caramel sauce with a caramel apple lollipop",
+      "location": "California Adventure",
+      "restaurant": "Pym Test Kitchen",
+      "price": null,
+      "category": "coffee-tea",
+      "itemType": "Coffee/Tea",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Chimichanga.jpg",
+      "tags": [
+        "non-alcoholic",
+        "apple",
+        "cold"
+      ]
+    },
+    {
+      "id": 64,
+      "name": "Blueberry Matcha Iced Latte",
+      "description": "Matcha latte topped with blueberry cold foam and blueberry popping spheres",
+      "location": "California Adventure",
+      "restaurant": "Pym Test Kitchen",
+      "price": null,
+      "category": "coffee-tea",
+      "itemType": "Coffee/Tea",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "coffee-tea",
+        "cold"
+      ]
+    },
+    {
+      "id": 65,
+      "name": "Newtopia Cyder Soiree Five Apple Blend",
+      "description": "",
+      "location": "California Adventure",
+      "restaurant": "Pym Test Kitchen",
+      "price": null,
+      "category": "beer-wine",
+      "itemType": "Beer/Wine",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "new",
+        "apple"
+      ]
+    },
+    {
+      "id": 66,
+      "name": "Chocolate Crème Brûlée Tart",
+      "description": "Raspberries and coconut chantilly cream",
+      "location": "California Adventure",
+      "restaurant": "Wine Country Trattoria",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "plant-based",
+        "vegan"
+      ]
+    },
+    {
+      "id": 67,
+      "name": "Mulled Wine",
+      "description": "Holiday-spiced warm wine",
+      "location": "California Adventure",
+      "restaurant": "Wine Country Trattoria",
+      "price": null,
+      "category": "beer-wine",
+      "itemType": "Beer/Wine",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "new",
+        "seasonal",
+        "cold",
+        "hot"
+      ]
+    },
+    {
+      "id": 68,
+      "name": "Pumpkin Crème Brûlée Cold Brew: Joffrey’s",
+      "description": "Pumpkin crème brûlée cold brew coffee with pumpkin sauce topped with cold cream foam",
+      "location": "California Adventure",
+      "restaurant": "Cozy Cone Motel 1 – Churros",
+      "price": null,
+      "category": "coffee-tea",
+      "itemType": "Coffee/Tea",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Apple-Churro.jpg",
+      "tags": [
+        "non-alcoholic",
+        "pumpkin-spice",
+        "coffee-tea",
+        "cold"
+      ]
+    },
+    {
+      "id": 69,
+      "name": "Hot Chocolate Vodka Cocktail",
+      "description": "with vanilla vodka topped with whipped cream and peppermint candy",
+      "location": "California Adventure",
+      "restaurant": "Cozy Cone Motel 1 – Churros",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Cocoa-Cocktail.jpg",
+      "tags": [
+        "alcoholic",
+        "new",
+        "peppermint",
+        "hot"
+      ]
+    },
+    {
+      "id": 70,
+      "name": "Cars-mas Tree Cone",
+      "description": "Peppermint soft serve decorated with holiday sprinkles",
+      "location": "California Adventure",
+      "restaurant": "Cozy Cone Motel 2 – Ice Cream Cones",
+      "price": null,
+      "category": "frozen-dessert",
+      "itemType": "Frozen Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "peppermint",
+        "seasonal"
+      ]
+    },
+    {
+      "id": 71,
+      "name": "Peppermint-Chocolate Twist Soft Serve",
+      "description": "",
+      "location": "California Adventure",
+      "restaurant": "Cozy Cone Motel 2 – Ice Cream Cones",
+      "price": null,
+      "category": "frozen-dessert",
+      "itemType": "Frozen Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "peppermint"
+      ]
+    },
+    {
+      "id": 72,
+      "name": "Peppermint Soft Serve",
+      "description": "",
+      "location": "California Adventure",
+      "restaurant": "Cozy Cone Motel 2 – Ice Cream Cones",
+      "price": null,
+      "category": "frozen-dessert",
+      "itemType": "Frozen Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "peppermint"
+      ]
+    },
+    {
+      "id": 73,
+      "name": "Apple Crumble",
+      "description": "topped with vanilla chantilly cream",
+      "location": "California Adventure",
+      "restaurant": "Flo’s V8 Cafe",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Apple-Crumble.jpg",
+      "tags": [
+        "new",
+        "apple",
+        "non-alcoholic"
+      ]
+    },
+    {
+      "id": 74,
+      "name": "Candy Cane Sourdough Bread (Plant-based)",
+      "description": "",
+      "location": "California Adventure",
+      "restaurant": "Boudin Bread Cart",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "plant-based",
+        "vegan"
+      ]
+    },
+    {
+      "id": 75,
+      "name": "Christmas Tree Pull-apart Sourdough Bread (Plant-based)",
+      "description": "",
+      "location": "California Adventure",
+      "restaurant": "Boudin Bread Cart",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "plant-based",
+        "vegan"
+      ]
+    },
+    {
+      "id": 76,
+      "name": "Snowman Sourdough Bread (Plant-based)",
+      "description": "",
+      "location": "California Adventure",
+      "restaurant": "Boudin Bread Cart",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "plant-based",
+        "vegan"
+      ]
+    },
+    {
+      "id": 77,
+      "name": "Ghirardelli Mexican Style Hot Cocoa",
+      "description": "Warm cinnamon and nutmeg along with a subtle bit of spice from cayenne mixed with Ghirardelli hot cocoa, topped with hot fudge whipped cream",
+      "location": "California Adventure",
+      "restaurant": "Ghirardelli Soda Fountain and Chocolate Shop",
+      "price": null,
+      "category": "candy-snack",
+      "itemType": "Candy/Snack",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Ghirardelli-1440x1080.jpg",
+      "tags": [
+        "non-alcoholic",
+        "new",
+        "cinnamon",
+        "hot"
+      ]
+    },
+    {
+      "id": 78,
+      "name": "Santa Baymax Macaron",
+      "description": "filled with peppermint buttercream, chocolate ganache, and dark chocolate crunchies",
+      "location": "California Adventure",
+      "restaurant": "Lucky Fortune Cookery",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Baymax-Macaron.jpg",
+      "tags": [
+        "non-alcoholic",
+        "peppermint"
+      ]
+    },
+    {
+      "id": 79,
+      "name": "Brewery Ommegang Everything Naughty",
+      "description": "White chocolate imperial blonde stout",
+      "location": "California Adventure",
+      "restaurant": "Lamplight Lounge – Boardwalk Dining",
+      "price": null,
+      "category": "beer-wine",
+      "itemType": "Beer/Wine",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Caramel-Donuts.jpg",
+      "tags": [
+        "alcoholic",
+        "new"
+      ]
+    },
+    {
+      "id": 80,
+      "name": "Java Martini",
+      "description": "Tequila, coffee and vanilla liqueurs, and hazelnut cream cold foam",
+      "location": "California Adventure",
+      "restaurant": "Lamplight Lounge – Boardwalk Dining",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "new",
+        "coffee-tea",
+        "cold",
+        "contains-nuts"
+      ]
+    },
+    {
+      "id": 81,
+      "name": "Lamplight Delight Donuts",
+      "description": "",
+      "location": "California Adventure",
+      "restaurant": "Lamplight Lounge",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Caramel-Donuts.jpg",
+      "tags": [
+        "non-alcoholic",
+        "new"
+      ]
+    },
+    {
+      "id": 82,
+      "name": "Java Martini",
+      "description": "Tequila, coffee and vanilla liqueurs, and hazelnut cream cold foam",
+      "location": "California Adventure",
+      "restaurant": "Lamplight Lounge",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "new",
+        "coffee-tea",
+        "cold",
+        "contains-nuts"
+      ]
+    },
+    {
+      "id": 83,
+      "name": "2 Towns Ciderhouse Cosmic Crisp",
+      "description": "",
+      "location": "California Adventure",
+      "restaurant": "Lamplight Lounge",
+      "price": null,
+      "category": "beer-wine",
+      "itemType": "Beer/Wine",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic"
+      ]
+    },
+    {
+      "id": 84,
+      "name": "Brewery X Spiced Sangria Seltzer",
+      "description": "Fruity and light spiced sangria seltzer (Michelada option available)",
+      "location": "California Adventure",
+      "restaurant": "Bayside Brews",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Michelada.jpg",
+      "tags": [
+        "alcoholic",
+        "cold"
+      ]
+    },
+    {
+      "id": 85,
+      "name": "Rincon Reservation Road Rez Dog Hefeweizen",
+      "description": "(Michelada option available)",
+      "location": "California Adventure",
+      "restaurant": "Bayside Brews",
+      "price": null,
+      "category": "beer-wine",
+      "itemType": "Beer/Wine",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic"
+      ]
+    },
+    {
+      "id": 86,
+      "name": "Watermelon Pineapple Margarita",
+      "description": "Tequila, watermelon schnapps, and pineapple juice with a chile-lime-seasoned rim",
+      "location": "California Adventure",
+      "restaurant": "Bayside Brews",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Watermelon-Margarita.jpg",
+      "tags": [
+        "alcoholic",
+        "apple"
+      ]
+    },
+    {
+      "id": 87,
+      "name": "Fried Elote Corn on the Cob",
+      "description": "dipped in batter and fried to golden brown, drizzled with chipotle aïoli, and topped with chile-lime queso fresco and cilantro served with Cuties Mandarin Orange or small bag of chips",
+      "location": "California Adventure",
+      "restaurant": "Corn Dog Castle",
+      "price": null,
+      "category": "savory-snack",
+      "itemType": "Savory Snack",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Fried-Elote.jpg",
+      "tags": [
+        "non-alcoholic",
+        "character-themed"
+      ]
+    },
+    {
+      "id": 88,
+      "name": "Fluffernutter Churro",
+      "description": "Classic churro with peanut butter sauce, marshmallow sauce, and chocolate chips",
+      "location": "California Adventure",
+      "restaurant": "Churros near Redwood Creek Challenge Trail",
+      "price": null,
+      "category": "churro",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Fluffernutter-Churro.jpg",
+      "tags": [
+        "non-alcoholic",
+        "character-themed"
+      ]
+    },
+    {
+      "id": 89,
+      "name": "BearPaw Basin Cold Brew",
+      "description": "Joffrey’s Pecan cold brew coffee, salted maple cold foam, caramel drizzle, and waffle pieces (Non-alocholic)",
+      "location": "California Adventure",
+      "restaurant": "Smokejumpers Grill",
+      "price": null,
+      "category": "coffee-tea",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Basin-Cold-Brew.jpg",
+      "tags": [
+        "non-alcoholic",
+        "coffee-tea",
+        "cold",
+        "contains-nuts"
+      ]
+    },
+    {
+      "id": 90,
+      "name": "Peppermint Mocha Shake",
+      "description": "Joffrey's Peppermint, chocolate, and coffee shake with whipped topping and peppermint candy pieces",
+      "location": "California Adventure",
+      "restaurant": "Smokejumpers Grill",
+      "price": null,
+      "category": "frozen-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Peppermint-Shake.jpg",
+      "tags": [
+        "non-alcoholic",
+        "peppermint",
+        "coffee-tea"
+      ]
+    },
+    {
+      "id": 91,
+      "name": "Karl Strauss Aurora Hoppyalis IPA",
+      "description": "",
+      "location": "California Adventure",
+      "restaurant": "Smokejumpers Grill",
+      "price": null,
+      "category": "beer-wine",
+      "itemType": "Beer/Wine",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "new"
+      ]
+    },
+    {
+      "id": 92,
+      "name": "Kona Brewing Co. Longboard Island Lager",
+      "description": "",
+      "location": "California Adventure",
+      "restaurant": "Smokejumpers Grill",
+      "price": null,
+      "category": "beer-wine",
+      "itemType": "Beer/Wine",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "new"
+      ]
+    },
+    {
+      "id": 93,
+      "name": "Caramel-Pecan Irish Cream Cold Brew Cocktail",
+      "description": "Irish cream liqueur, Joffrey's pecan cold brew coffee, salted maple cold foam, caramel drizzle, and waffle pieces",
+      "location": "California Adventure",
+      "restaurant": "Smokejumpers Grill",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Pecan-Cocktail.jpg",
+      "tags": [
+        "alcoholic",
+        "coffee-tea",
+        "cold",
+        "contains-nuts"
+      ]
+    },
+    {
+      "id": 94,
+      "name": "Eggnog",
+      "description": "House-made eggnog",
+      "location": "Disneyland Hotel",
+      "restaurant": "Broken Spell Lounge",
+      "price": null,
+      "category": "non-alcoholic-beverage",
+      "itemType": "Non-Alcoholic Beverage",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Marshmallow-Cocktail.jpg",
+      "tags": [
+        "non-alcoholic",
+        "eggnog"
+      ]
+    },
+    {
+      "id": 95,
+      "name": "Hot Chocolate",
+      "description": "House-made hot chocolate",
+      "location": "Disneyland Hotel",
+      "restaurant": "Broken Spell Lounge",
+      "price": null,
+      "category": "candy-snack",
+      "itemType": "Candy/Snack",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "hot"
+      ]
+    },
+    {
+      "id": 96,
+      "name": "Coal Manhattan",
+      "description": "WhistlePig PiggyBack 6-Year Rye, Amaro Averna, St. Elizabeth Allspice Dram, and bitters",
+      "location": "Disneyland Hotel",
+      "restaurant": "Broken Spell Lounge",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic"
+      ]
+    },
+    {
+      "id": 97,
+      "name": "Eggnog Cocktail",
+      "description": "House-made eggnog, Fonseca Bin 27 Port, Pierre Ferrand Cognac, and Smith & Cross Jamaican Pot Still Rum",
+      "location": "Disneyland Hotel",
+      "restaurant": "Broken Spell Lounge",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "eggnog"
+      ]
+    },
+    {
+      "id": 98,
+      "name": "Five Golden Rings",
+      "description": "Golden Eagle Vodka, St-Germain Elderflower Liqueur, ginger, rosemary, cranberry flavors with edible shimmer glitter",
+      "location": "Disneyland Hotel",
+      "restaurant": "Broken Spell Lounge",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "cranberry"
+      ]
+    },
+    {
+      "id": 99,
+      "name": "Hot Chocolate Cocktail",
+      "description": "House-made hot chocolate with Plantation Dark Rum and Drambuie Liquor",
+      "location": "Disneyland Hotel",
+      "restaurant": "Broken Spell Lounge",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "hot"
+      ]
+    },
+    {
+      "id": 100,
+      "name": "Mulled Wine",
+      "description": "The Fableist Wine Company The Silkworm and the Spider Pinot Noir with mulled spices served over ice",
+      "location": "Disneyland Hotel",
+      "restaurant": "Broken Spell Lounge",
+      "price": null,
+      "category": "beer-wine",
+      "itemType": "Beer/Wine",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic"
+      ]
+    },
+    {
+      "id": 101,
+      "name": "Peppermint Kiss",
+      "description": "Peppermint-infused Golden Eagle Vodka, Crème de Cacao, Crème de Menthe, Coco Lopez Coconut Crème, and house-made Frangelico whipped cream",
+      "location": "Disneyland Hotel",
+      "restaurant": "Broken Spell Lounge",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "peppermint"
+      ]
+    },
+    {
+      "id": 102,
+      "name": "Prickly Pear French 75",
+      "description": "Condesa Prickly Pear Gin, St. George Spiced Pear Liqueur, Piper Sonoma Brut, honey, and lemon juice",
+      "location": "Disneyland Hotel",
+      "restaurant": "Broken Spell Lounge",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "cold"
+      ]
+    },
+    {
+      "id": 103,
+      "name": "Thanksgiving Mule",
+      "description": "Tequila, Liquid Alchemist Ginger Syrup, cranberry sauce, celery salt, lime juice, and sage leaves",
+      "location": "Disneyland Hotel",
+      "restaurant": "Broken Spell Lounge",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "cranberry"
+      ]
+    },
+    {
+      "id": 104,
+      "name": "Pumpkin Spice Latte",
+      "description": "Espresso, pumpkin spice syrup, and milk",
+      "location": "Disneyland Hotel",
+      "restaurant": "Goofy’s Kitchen",
+      "price": null,
+      "category": "coffee-tea",
+      "itemType": "Coffee/Tea",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Goofys-Kitchen-1623x1080.jpg",
+      "tags": [
+        "non-alcoholic",
+        "new",
+        "pumpkin-spice",
+        "coffee-tea",
+        "cold",
+        "hot"
+      ]
+    },
+    {
+      "id": 105,
+      "name": "Chai Ginger Latte",
+      "description": "Espresso, milk, chai syrup, white chocolate sauce, and gingerbread whipped cream",
+      "location": "Disneyland Hotel",
+      "restaurant": "Goofy’s Kitchen",
+      "price": null,
+      "category": "coffee-tea",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "gingerbread",
+        "coffee-tea",
+        "cold",
+        "hot"
+      ]
+    },
+    {
+      "id": 106,
+      "name": "Eggnog",
+      "description": "House-made eggnog",
+      "location": "Disneyland Hotel",
+      "restaurant": "Goofy’s Kitchen",
+      "price": null,
+      "category": "non-alcoholic-beverage",
+      "itemType": "Non-Alcoholic Beverage",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "eggnog"
+      ]
+    },
+    {
+      "id": 107,
+      "name": "Eggnog Latte",
+      "description": "House-made eggnog with two shots of espresso",
+      "location": "Disneyland Hotel",
+      "restaurant": "Goofy’s Kitchen",
+      "price": null,
+      "category": "coffee-tea",
+      "itemType": "Coffee/Tea",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "eggnog",
+        "coffee-tea",
+        "cold",
+        "hot"
+      ]
+    },
+    {
+      "id": 108,
+      "name": "Eggnog Cocktail",
+      "description": "House-made eggnog, Fonseca Bin 27 Port, Pierre Ferrand Cognac, and Smith & Cross Jamaican Pot Still Rum",
+      "location": "Disneyland Hotel",
+      "restaurant": "Goofy’s Kitchen",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "eggnog"
+      ]
+    },
+    {
+      "id": 109,
+      "name": "Mulled Wine",
+      "description": "The Fableist Wine Company The Silkworm and the Spider Pinot Noir with mulled spices, served over ice",
+      "location": "Disneyland Hotel",
+      "restaurant": "Goofy’s Kitchen",
+      "price": null,
+      "category": "beer-wine",
+      "itemType": "Beer/Wine",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic"
+      ]
+    },
+    {
+      "id": 110,
+      "name": "Mickey-shaped Gingerbread Cookie",
+      "description": "Soft gingerbread Mickey cookie with sprinkles",
+      "location": "Disneyland Hotel",
+      "restaurant": "The Coffee House",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Rice-Treat.jpg",
+      "tags": [
+        "gingerbread",
+        "character-themed",
+        "non-alcoholic"
+      ]
+    },
+    {
+      "id": 111,
+      "name": "Mickey-shaped Holiday Cookie",
+      "description": "Shortbread cookie dipped in white chocolate with holiday sprinkles, and a chocolate Mickey decoration",
+      "location": "Disneyland Hotel",
+      "restaurant": "The Coffee House",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "character-themed",
+        "seasonal"
+      ]
+    },
+    {
+      "id": 112,
+      "name": "Peppermint Crisped Rice Treat",
+      "description": "",
+      "location": "Disneyland Hotel",
+      "restaurant": "The Coffee House",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "peppermint"
+      ]
+    },
+    {
+      "id": 113,
+      "name": "Cinnamon Roll Latte",
+      "description": "Espresso, milk, white chocolate sauce, brown sugar, cinnamon, and whipped cream",
+      "location": "Disneyland Hotel",
+      "restaurant": "The Coffee House",
+      "price": null,
+      "category": "coffee-tea",
+      "itemType": "Coffee/Tea",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "new",
+        "cinnamon",
+        "coffee-tea",
+        "cold",
+        "hot"
+      ]
+    },
+    {
+      "id": 114,
+      "name": "Eggnog",
+      "description": "House-made eggnog",
+      "location": "Disneyland Hotel",
+      "restaurant": "The Coffee House",
+      "price": null,
+      "category": "non-alcoholic-beverage",
+      "itemType": "Non-Alcoholic Beverage",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "eggnog",
+        "cold",
+        "hot"
+      ]
+    },
+    {
+      "id": 115,
+      "name": "Chai Ginger Latte",
+      "description": "Espresso, milk, chai syrup, white chocolate sauce, and gingerbread whipped cream",
+      "location": "Disneyland Hotel",
+      "restaurant": "The Coffee House",
+      "price": null,
+      "category": "coffee-tea",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "gingerbread",
+        "coffee-tea",
+        "cold",
+        "hot"
+      ]
+    },
+    {
+      "id": 116,
+      "name": "Eggnog Latte",
+      "description": "House-made eggnog with a shot of espresso",
+      "location": "Disneyland Hotel",
+      "restaurant": "The Coffee House",
+      "price": null,
+      "category": "coffee-tea",
+      "itemType": "Coffee/Tea",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "eggnog",
+        "coffee-tea",
+        "cold",
+        "hot"
+      ]
+    },
+    {
+      "id": 117,
+      "name": "Peppermint Mocha",
+      "description": "topped with whipped cream",
+      "location": "Disneyland Hotel",
+      "restaurant": "The Coffee House",
+      "price": null,
+      "category": "coffee-tea",
+      "itemType": "Coffee/Tea",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "peppermint",
+        "cold",
+        "hot"
+      ]
+    },
+    {
+      "id": 118,
+      "name": "Pumpkin Spice Latte",
+      "description": "Espresso, pumpkin spice syrup, and milk",
+      "location": "Disneyland Hotel",
+      "restaurant": "The Coffee House",
+      "price": null,
+      "category": "coffee-tea",
+      "itemType": "Coffee/Tea",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "pumpkin-spice",
+        "coffee-tea",
+        "cold",
+        "hot"
+      ]
+    },
+    {
+      "id": 119,
+      "name": "S’mores Hot Chocolate",
+      "description": "topped with toasted marshmallow foam",
+      "location": "Disneyland Hotel",
+      "restaurant": "The Coffee House",
+      "price": null,
+      "category": "candy-snack",
+      "itemType": "Candy/Snack",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "hot"
+      ]
+    },
+    {
+      "id": 120,
+      "name": "Crisp Nights",
+      "description": "Parrot Bay Coconut Rum, Tito’s Handmade Vodka, lemon juice, and simple syrup",
+      "location": "Disneyland Hotel",
+      "restaurant": "Trader Sam’s Enchanted Tiki Bar",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "new"
+      ]
+    },
+    {
+      "id": 121,
+      "name": "Holichata",
+      "description": "Bacardi Reserva Ocho Rum, Frangelico Liqueur, St. Elizabeth Allspice Dram Liqueur, house-made Colibri mix, cinnamon syrup, and lemon juice",
+      "location": "Disneyland Hotel",
+      "restaurant": "Trader Sam’s Enchanted Tiki Bar",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "new",
+        "cinnamon"
+      ]
+    },
+    {
+      "id": 122,
+      "name": "Old Fashioned Joy",
+      "description": "Buffalo Trace Bourbon, Giffard’s Banana Liqueur, maple syrup, and walnut bitters",
+      "location": "Disneyland Hotel",
+      "restaurant": "Trader Sam’s Enchanted Tiki Bar",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "new",
+        "contains-nuts"
+      ]
+    },
+    {
+      "id": 123,
+      "name": "Yuletide Cheers",
+      "description": "Zaya Rum, Avissi Prosecco, pomegranate and cranberry juices, and cinnamon syrup",
+      "location": "Disneyland Hotel",
+      "restaurant": "Trader Sam’s Enchanted Tiki Bar",
+      "price": null,
+      "category": "beer-wine",
+      "itemType": "Beer/Wine",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "new",
+        "cranberry",
+        "cinnamon"
+      ]
+    },
+    {
+      "id": 124,
+      "name": "Christmas Jumbo Cake Pop",
+      "description": "Chocolate cake pop dipped in white chocolate",
+      "location": "Disney’s Grand Californian Hotel & Spa",
+      "restaurant": "Grand Californian Great Hall Cart",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Lights-Pop.jpg",
+      "tags": [
+        "non-alcoholic",
+        "new"
+      ]
+    },
+    {
+      "id": 125,
+      "name": "Holiday Tea Cake Variety Box",
+      "description": "Vanilla Bean, Double Chocolate, Gingerbread, and Orange-cranberry individually wrapped tea cakes",
+      "location": "Disney’s Grand Californian Hotel & Spa",
+      "restaurant": "Grand Californian Great Hall Cart",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "new",
+        "gingerbread",
+        "cranberry",
+        "seasonal",
+        "coffee-tea",
+        "non-alcoholic"
+      ]
+    },
+    {
+      "id": 126,
+      "name": "Mickey Snowman Macaron",
+      "description": "",
+      "location": "Disney’s Grand Californian Hotel & Spa",
+      "restaurant": "Grand Californian Great Hall Cart",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "new",
+        "character-themed"
+      ]
+    },
+    {
+      "id": 127,
+      "name": "Raspberry Coconut Wreath",
+      "description": "Almond shortbread cookie with coconut macaron ring, filled with raspberry jam",
+      "location": "Disney’s Grand Californian Hotel & Spa",
+      "restaurant": "Grand Californian Great Hall Cart",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "new",
+        "contains-nuts"
+      ]
+    },
+    {
+      "id": 128,
+      "name": "Santa Jumbo Cake Pop",
+      "description": "Chocolate cake pop dipped in white chocolate",
+      "location": "Disney’s Grand Californian Hotel & Spa",
+      "restaurant": "Grand Californian Great Hall Cart",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "new"
+      ]
+    },
+    {
+      "id": 129,
+      "name": "Holiday Cookie Box",
+      "description": "Assorted cookies",
+      "location": "Disney’s Grand Californian Hotel & Spa",
+      "restaurant": "Grand Californian Great Hall Cart",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "seasonal"
+      ]
+    },
+    {
+      "id": 130,
+      "name": "Holiday Crisped Rice Treat",
+      "description": "",
+      "location": "Disney’s Grand Californian Hotel & Spa",
+      "restaurant": "Grand Californian Great Hall Cart",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "seasonal"
+      ]
+    },
+    {
+      "id": 131,
+      "name": "Mickey-shaped Gingerbread Cookie",
+      "description": "",
+      "location": "Disney’s Grand Californian Hotel & Spa",
+      "restaurant": "Grand Californian Great Hall Cart",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "gingerbread",
+        "character-themed",
+        "non-alcoholic"
+      ]
+    },
+    {
+      "id": 132,
+      "name": "Mickey-shaped Poinsettia Cookie",
+      "description": "",
+      "location": "Disney’s Grand Californian Hotel & Spa",
+      "restaurant": "Grand Californian Great Hall Cart",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "character-themed"
+      ]
+    },
+    {
+      "id": 133,
+      "name": "Seasonal Loaf Cake",
+      "description": "",
+      "location": "Disney’s Grand Californian Hotel & Spa",
+      "restaurant": "Grand Californian Great Hall Cart",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic"
+      ]
+    },
+    {
+      "id": 134,
+      "name": "Eggnog",
+      "description": "House-made eggnog (Also available with Bailey’s Original Irish Cream Liqueur)",
+      "location": "Disney’s Grand Californian Hotel & Spa",
+      "restaurant": "Grand Californian Great Hall Cart",
+      "price": null,
+      "category": "non-alcoholic-beverage",
+      "itemType": "Non-Alcoholic Beverage",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "eggnog"
+      ]
+    },
+    {
+      "id": 135,
+      "name": "Hot Apple Cider",
+      "description": "",
+      "location": "Disney’s Grand Californian Hotel & Spa",
+      "restaurant": "Grand Californian Great Hall Cart",
+      "price": null,
+      "category": "beer-wine",
+      "itemType": "Beer/Wine",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "apple",
+        "hot"
+      ]
+    },
+    {
+      "id": 136,
+      "name": "Hot Chocolate",
+      "description": "House-made hot chocolate (Also available with Bailey’s Original Irish Cream Liqueur)",
+      "location": "Disney’s Grand Californian Hotel & Spa",
+      "restaurant": "Grand Californian Great Hall Cart",
+      "price": null,
+      "category": "candy-snack",
+      "itemType": "Candy/Snack",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "hot"
+      ]
+    },
+    {
+      "id": 137,
+      "name": "Chocolate Peppermint Long John Donut",
+      "description": "",
+      "location": "Disney’s Grand Californian Hotel & Spa",
+      "restaurant": "GCH Craftsman Grill",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "new",
+        "peppermint"
+      ]
+    },
+    {
+      "id": 138,
+      "name": "Christmas Tree Cupcake",
+      "description": "",
+      "location": "Disney’s Grand Californian Hotel & Spa",
+      "restaurant": "GCH Craftsman Grill",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "new"
+      ]
+    },
+    {
+      "id": 139,
+      "name": "Cranberry Orange Muffin",
+      "description": "",
+      "location": "Disney’s Grand Californian Hotel & Spa",
+      "restaurant": "GCH Craftsman Grill",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "new",
+        "cranberry"
+      ]
+    },
+    {
+      "id": 140,
+      "name": "Eggnog Muffin",
+      "description": "",
+      "location": "Disney’s Grand Californian Hotel & Spa",
+      "restaurant": "GCH Craftsman Grill",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "new",
+        "eggnog"
+      ]
+    },
+    {
+      "id": 141,
+      "name": "Holiday Cake Donut",
+      "description": "",
+      "location": "Disney’s Grand Californian Hotel & Spa",
+      "restaurant": "GCH Craftsman Grill",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "new",
+        "seasonal"
+      ]
+    },
+    {
+      "id": 142,
+      "name": "Clark’s Nutcracker",
+      "description": "Rum, lime juice, agave, cranberry, orange clove syrup, and cinnamon all served in a nutcracker glass",
+      "location": "Downtown Disney District",
+      "restaurant": "Vista Parkside Market",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Parkside-Market-1440x1080.jpg",
+      "tags": [
+        "alcoholic",
+        "new",
+        "cranberry",
+        "cinnamon"
+      ]
+    },
+    {
+      "id": 143,
+      "name": "Fancy Bird",
+      "description": "Rye Scotch whisky, lime juice, orgeat, and orange curaçao all served in a Vista Holiday Rocks glass",
+      "location": "Downtown Disney District",
+      "restaurant": "Vista Parkside Market",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "seasonal"
+      ]
+    },
+    {
+      "id": 144,
+      "name": "Michael in a Pear Tree",
+      "description": "Tequila blanco, pear nectar, lime juice, and rosemary simple syrup all served in a bird glass",
+      "location": "Downtown Disney District",
+      "restaurant": "Vista Parkside Market",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "new"
+      ]
+    },
+    {
+      "id": 145,
+      "name": "Scarlet Tanager",
+      "description": "Bourbon, amaro liqueur, orange-flavored liqueur, and cinnamon bitters all served in a Vista Holiday Rocks glass",
+      "location": "Downtown Disney District",
+      "restaurant": "Vista Parkside Market",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "new",
+        "cinnamon",
+        "seasonal"
+      ]
+    },
+    {
+      "id": 146,
+      "name": "Peppermint Churro",
+      "description": "Churro rolled in peppermint powdered sugar, with a peppermint icing drizzled on top, and covered in crushed candy cane pieces",
+      "location": "Downtown Disney District",
+      "restaurant": "California Churro",
+      "price": null,
+      "category": "churro",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Peppermint-Churro.jpeg",
+      "tags": [
+        "non-alcoholic",
+        "new",
+        "peppermint"
+      ]
+    },
+    {
+      "id": 147,
+      "name": "Three Course Christmas Dinner",
+      "description": "",
+      "location": "Downtown Disney District",
+      "restaurant": "Jazz Kitchen Coastal Grill & Patio",
+      "price": null,
+      "category": "entree",
+      "itemType": "Entree",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Christmas-Meal-810x1080.jpg",
+      "tags": [
+        "non-alcoholic",
+        "new",
+        "savory"
+      ]
+    },
+    {
+      "id": 148,
+      "name": "Gingerbread Old Fashion",
+      "description": "Spirited blend of bourbon and gingerbread spice syrup",
+      "location": "Downtown Disney District",
+      "restaurant": "Jazz Kitchen Coastal Grill & Patio",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "new",
+        "gingerbread"
+      ]
+    },
+    {
+      "id": 149,
+      "name": "Candy Cane Twist Glazed Beignet",
+      "description": "Beignet coated in a frosty peppermint glaze with crushed green candy",
+      "location": "Downtown Disney District",
+      "restaurant": "Beignets Expressed",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Holiday-Beignet-810x1080.jpg",
+      "tags": [
+        "non-alcoholic",
+        "peppermint"
+      ]
+    },
+    {
+      "id": 150,
+      "name": "Seasonal Mini Cheesecakes",
+      "description": "including Peppermint Chocolate, Pumpkin Spice, Mango, and Strawberry",
+      "location": "Downtown Disney District",
+      "restaurant": "Splitsville Luxury Lanes",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "pumpkin-spice",
+        "peppermint"
+      ]
+    },
+    {
+      "id": 151,
+      "name": "White Christmas Margarita",
+      "description": "Tequila, coconut milk, lime juice, and orange liqueur topped with rosemary and cranberries",
+      "location": "Downtown Disney District",
+      "restaurant": "Splitsville Luxury Lanes",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic"
+      ]
+    },
+    {
+      "id": 152,
+      "name": "Tamal de Rajas",
+      "description": "Corn husk tamal, rajas, Mexican cheese blend, and pickled jalapeños, carrots and squash veggies",
+      "location": "Downtown Disney District",
+      "restaurant": "Céntrico",
+      "price": null,
+      "category": "entree",
+      "itemType": "Entree",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Chicken-Tamal.jpg",
+      "tags": [
+        "non-alcoholic",
+        "new"
+      ]
+    },
+    {
+      "id": 153,
+      "name": "Mexican Hot Chocolate",
+      "description": "A rich, velvety hot chocolate served in the style of traditional Mexican “chocolate para mesa” — thick, luscious and spiced",
+      "location": "Downtown Disney District",
+      "restaurant": "Céntrico",
+      "price": null,
+      "category": "candy-snack",
+      "itemType": "Candy/Snack",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "new",
+        "cold",
+        "hot"
+      ]
+    },
+    {
+      "id": 154,
+      "name": "Berry MexMas",
+      "description": "Tequila reposado, black cherry, and lime juice",
+      "location": "Downtown Disney District",
+      "restaurant": "Céntrico",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "new"
+      ]
+    },
+    {
+      "id": 155,
+      "name": "Frosty Fiesta",
+      "description": "Horchata cream liquor, rum, cinnamon whiskey, and horchata",
+      "location": "Downtown Disney District",
+      "restaurant": "Céntrico",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "new",
+        "cinnamon"
+      ]
+    },
+    {
+      "id": 156,
+      "name": "Holiday Buñuelo",
+      "description": "with holiday sugar candy and orange cinnamon sugar",
+      "location": "Downtown Disney District",
+      "restaurant": "Tiendita",
+      "price": null,
+      "category": "candy-snack",
+      "itemType": "Candy/Snack",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Cornish-Hen.jpg",
+      "tags": [
+        "non-alcoholic",
+        "cinnamon",
+        "seasonal"
+      ]
+    },
+    {
+      "id": 157,
+      "name": "Tis’ the season for Pizza Bitz!",
+      "description": "Buttery pretzel bitz, rolled in cheese, and adorned with a pepperoni slice",
+      "location": "Downtown Disney District",
+      "restaurant": "Wetzel’s Pretzels",
+      "price": null,
+      "category": "savory-snack",
+      "itemType": "Savory Snack",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Prime-Rib.jpg",
+      "tags": [
+        "non-alcoholic"
+      ]
+    },
+    {
+      "id": 158,
+      "name": "Christmas Cider",
+      "description": "Peanut butter whiskey, apple cider, hibiscus tea with edible glitter, lemon juice",
+      "location": "Downtown Disney District",
+      "restaurant": "Naples Ristorante e Bar",
+      "price": null,
+      "category": "beer-wine",
+      "itemType": "Beer/Wine",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": "https://disneyparksblog.com/app/uploads/2025/11/2025-DLR-Holiday-Foodie-Guide-Pizza.jpg",
+      "tags": [
+        "alcoholic",
+        "new",
+        "apple",
+        "coffee-tea"
+      ]
+    },
+    {
+      "id": 159,
+      "name": "Santa’s Margarita",
+      "description": "Tequila blanco, peach schnapps, margarita mix, cranberry juice, and black raspberry liquor",
+      "location": "Downtown Disney District",
+      "restaurant": "Naples Ristorante e Bar",
+      "price": null,
+      "category": "cocktail",
+      "itemType": "Cocktail",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "new",
+        "cranberry"
+      ]
+    },
+    {
+      "id": 160,
+      "name": "Twisted Christmas Cider",
+      "description": "Peanut butter whiskey, apple cider, hibiscus team, edible glitter, and lemon juice",
+      "location": "Downtown Disney District",
+      "restaurant": "Naples Ristorante e Bar",
+      "price": null,
+      "category": "beer-wine",
+      "itemType": "Beer/Wine",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "alcoholic",
+        "new",
+        "apple",
+        "coffee-tea"
+      ]
+    },
+    {
+      "id": 161,
+      "name": "Chocolate Spice Macaron Croissant",
+      "description": "Flaky butter croissant filled with silky chocolate custard infused with holiday spices, finished with delicate macaron shell",
+      "location": "Downtown Disney District",
+      "restaurant": "Kayla’s Cake",
+      "price": null,
+      "category": "baked-dessert",
+      "itemType": "Baked Dessert",
+      "mobileOrderAvailable": false,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "non-alcoholic",
+        "new",
+        "seasonal"
+      ]
+    },
+    {
+      "id": 162,
+      "name": "Santa Breakfast Potato",
+      "description": "Scrambled eggs, shredded cheese, country sausage gravy, and green onions (Served until 11 a.m. or until supplies last)",
+      "location": "Disneyland",
+      "restaurant": "Troubadour Tavern",
+      "price": 12.69,
+      "category": "entree",
+      "itemType": "Entree",
+      "mobileOrderAvailable": true,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "savory",
+        "new",
+        "non-alcoholic",
+        "seasonal"
+      ]
+    },
+    {
+      "id": 163,
+      "name": "Celebration Dinner Potato",
+      "description": "Baked potato with pulled smoked turkey, whipped cream cheese, stuffing, cranberry sauce, gravy, and fried onions",
+      "location": "Disneyland",
+      "restaurant": "Troubadour Tavern",
+      "price": null,
+      "category": "entree",
+      "itemType": "Entree",
+      "mobileOrderAvailable": true,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "savory",
+        "non-alcoholic",
+        "seasonal",
+        "cranberry"
+      ]
+    },
+    {
+      "id": 164,
+      "name": "Holiday Beef Dinner Potato",
+      "description": "Sliced tri-tip steak, spinach artichoke dip, demi-glace, and crispy onions",
+      "location": "Disneyland",
+      "restaurant": "Troubadour Tavern",
+      "price": null,
+      "category": "entree",
+      "itemType": "Entree",
+      "mobileOrderAvailable": true,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "savory",
+        "non-alcoholic",
+        "seasonal"
+      ]
+    },
+    {
+      "id": 165,
+      "name": "Holiday Popcorn",
+      "description": "White chocolate-dusted butter popcorn with a mix of M&M'S Milk Chocolate Candies, pretzel sticks, and crushed peppermint",
+      "location": "Disneyland",
+      "restaurant": "Troubadour Tavern",
+      "price": null,
+      "category": "candy-snack",
+      "itemType": "Candy/Snack",
+      "mobileOrderAvailable": true,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "new",
+        "non-alcoholic",
+        "peppermint"
+      ]
+    },
+    {
+      "id": 166,
+      "name": "Holiday Cookie Cold Brew",
+      "description": "Joffrey's Dark chocolate Cold Brew Coffee with cookie butter topper and a sugar cookie (Non-alcoholic)",
+      "location": "Disneyland",
+      "restaurant": "Troubadour Tavern",
+      "price": null,
+      "category": "coffee-tea",
+      "itemType": "Coffee/Tea",
+      "mobileOrderAvailable": true,
+      "availability": {
+        "startDate": "2025-11-14",
+        "endDate": "2026-01-07"
+      },
+      "imageUrl": null,
+      "tags": [
+        "coffee-tea",
+        "non-alcoholic",
+        "cold",
+        "new"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
- Added 5 new holiday menu items from Troubadour Tavern
  - Santa Breakfast Potato ($12.69)
  - Celebration Dinner Potato
  - Holiday Beef Dinner Potato
  - Holiday Popcorn
  - Holiday Cookie Cold Brew
- Added "Troubadour Tavern" to restaurants list
- Updated totalItems count from 161 to 166
- All items available Nov 14, 2025 - Jan 7, 2026
- Mobile order available for all items